### PR TITLE
Dockerfile now is properly set up to run tests in a rootless container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,21 @@
 # Also needs to be updated in galaxy.yml
 VERSION = 0.1.0
 
+# To run sanity tests in docker, set SANITY_TEST_ARGS to '--docker'
+SANITY_TEST_ARGS ?= '--venv'
+
 clean:
-	rm -f community-okd-${VERSION}.tar.gz
+	rm -f community-okd-$(VERSION).tar.gz
 	rm -rf ansible_collections
 
 build: clean
 	ansible-galaxy collection build
 
 install: build
-	ansible-galaxy collection install -p ansible_collections community-okd-${VERSION}.tar.gz
+	ansible-galaxy collection install -p ansible_collections community-okd-$(VERSION).tar.gz
 
 test-sanity: install
-	cd ansible_collections/community/okd && ansible-test sanity -v --docker --color $(TEST_ARGS)
+	cd ansible_collections/community/okd && ansible-test sanity -v --color $(SANITY_TEST_ARGS)
 
 test-integration: install
 	molecule test

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Also needs to be updated in galaxy.yml
 VERSION = 0.1.0
 
-# To run sanity tests in docker, set SANITY_TEST_ARGS to '--docker'
-SANITY_TEST_ARGS ?= '--venv'
+# To run sanity tests in a venv, set SANITY_TEST_ARGS to '--venv'
+SANITY_TEST_ARGS ?= '--docker'
 
 clean:
 	rm -f community-okd-$(VERSION).tar.gz

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,14 +1,33 @@
 FROM registry.access.redhat.com/ubi8/ubi
 
-RUN yum install -y make python3 python3-devel python3-pip python3-setuptools \
+ENV OPERATOR=/usr/local/bin/ansible-operator \
+    USER_UID=1001 \
+    USER_NAME=ansible-operator\
+    HOME=/opt/ansible \
+    ANSIBLE_LOCAL_TMP=/opt/ansible/tmp
+
+RUN yum install -y \
+      glibc-langpack-en \
+      git \
+      make \
+      python3 \
+      python3-devel \
+      python3-pip \
+      python3-setuptools \
  && pip3 install --upgrade setuptools pip \
  && pip3 install \
       openshift \
       ansible \
       molecule
 
-WORKDIR /src
+COPY . /opt/ansible
 
-COPY . /src
+WORKDIR /opt/ansible
 
-USER 1001
+RUN echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" >> /etc/passwd \
+ && mkdir -p "${HOME}/.ansible/tmp" \
+ && chown -R "${USER_UID}:0" "${HOME}" \
+ && chmod -R ug+rw "${HOME}"
+
+
+USER ${USER_UID}


### PR DESCRIPTION
##### SUMMARY
The Dockerfile can now properly run ansible sanity tests without failing. The `test-sanity` make target was updated to allow replacing `--docker` with `--venv` in the `ansible-test` invocation

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
