### PR TITLE
Don't update image field when we can't manage it

### DIFF
--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -189,7 +189,7 @@ f_test_integration_option()
     f_install_kubernetes_core_from_src
     pushd "${_build_dir}" || return
         f_log_info "INTEGRATION TEST WD: ${PWD}"
-        molecule test
+        OVERRIDE_COLLECTION_PATH="${_tmp_dir}" molecule test
     popd || return
     f_cleanup
 }

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -133,9 +133,8 @@ f_install_kubernetes_core_from_src()
     #        ansible-galaxy collection install -p "${install_collections_dir}" "${community_k8s_tmpdir}"/kubernetes-core-*.tar.gz
     #    popd
     #popd
-        git clone https://github.com/maxamillion/community.kubernetes "${community_k8s_tmpdir}"
+        git clone https://github.com/ansible-collections/community.kubernetes "${community_k8s_tmpdir}"
         pushd "${community_k8s_tmpdir}"
-            git checkout downstream/fix_collection_name
             make downstream-build
             ansible-galaxy collection install -p "${install_collections_dir}" "${community_k8s_tmpdir}"/kubernetes-core-*.tar.gz
         popd

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -189,7 +189,7 @@ f_test_integration_option()
     f_install_kubernetes_core_from_src
     pushd "${_build_dir}" || return
         f_log_info "INTEGRATION TEST WD: ${PWD}"
-        make test-integration-incluster
+        molecule test
     popd || return
     f_cleanup
 }

--- a/ci/incluster_integration.sh
+++ b/ci/incluster_integration.sh
@@ -52,7 +52,7 @@ spec:
 EOF
 
 function check_success {
-  oc wait --for=condition=complete job/molecule-integration-test --timeout 5s \
+  oc wait --for=condition=complete job/molecule-integration-test --timeout 5s -n $NAMESPACE \
    && oc logs job/molecule-integration-test \
    && echo "Molecule integration tests ran successfully" \
    && return 0
@@ -60,7 +60,7 @@ function check_success {
 }
 
 function check_failure {
-  oc wait --for=condition=failed job/molecule-integration-test --timeout 5s \
+  oc wait --for=condition=failed job/molecule-integration-test --timeout 5s -n $NAMESPACE \
    && oc logs job/molecule-integration-test \
    && echo "Molecule integration tests failed, see logs for more information..." \
    && return 0

--- a/ci/incluster_integration.sh
+++ b/ci/incluster_integration.sh
@@ -2,6 +2,8 @@
 
 set -x
 
+NAMESPACE=${NAMESPACE:-default}
+
 # IMAGE_FORMAT is in the form $registry/$org/$image:$$component, ie
 # quay.io/openshift/release:$component
 # To test with your own image, build and push the test image
@@ -13,6 +15,13 @@ component='molecule-test-runner'
 eval IMAGE=$IMAGE_FORMAT
 
 PULL_POLICY=${PULL_POLICY:-IfNotPresent}
+
+if ! oc get namespace $NAMESPACE
+then
+  oc create namespace $NAMESPACE
+fi
+
+oc project $NAMESPACE
 
 echo "Deleting test job if it exists"
 oc delete job molecule-integration-test --wait --ignore-not-found
@@ -71,3 +80,5 @@ do
   fi
   sleep 10
 done
+
+exit 1

--- a/ci/incluster_integration.sh
+++ b/ci/incluster_integration.sh
@@ -42,6 +42,7 @@ EOF
 
 function wait_for_success {
   oc wait --for=condition=complete job/molecule-integration-test --timeout 5m
+  oc logs job/molecule-integration-test
   echo "Molecule integration tests ran successfully"
   exit 0
 }

--- a/ci/incluster_integration.sh
+++ b/ci/incluster_integration.sh
@@ -22,7 +22,8 @@ then
 fi
 
 oc project $NAMESPACE
-oc adm policy add-cluster-role-to-user admin -z default
+oc adm policy add-cluster-role-to-user cluster-admin -z default
+oc adm policy who-can create projectrequests
 
 echo "Deleting test job if it exists"
 oc delete job molecule-integration-test --wait --ignore-not-found

--- a/ci/incluster_integration.sh
+++ b/ci/incluster_integration.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-NAMESPACE=${NAMESPACE:-ansible-okd-test}
+NAMESPACE=${NAMESPACE:-default}
 
 # IMAGE_FORMAT is in the form $registry/$org/$image:$$component, ie
 # quay.io/openshift/release:$component

--- a/ci/incluster_integration.sh
+++ b/ci/incluster_integration.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-NAMESPACE=${NAMESPACE:-default}
+NAMESPACE=${NAMESPACE:-ansible-okd-test}
 
 # IMAGE_FORMAT is in the form $registry/$org/$image:$$component, ie
 # quay.io/openshift/release:$component
@@ -22,6 +22,7 @@ then
 fi
 
 oc project $NAMESPACE
+oc adm policy add-cluster-role-to-user admin -z default
 
 echo "Deleting test job if it exists"
 oc delete job molecule-integration-test --wait --ignore-not-found

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -49,18 +49,6 @@
       debug:
         var: output
 
-- name: Converge
-  hosts: localhost
-  connection: local
-  gather_facts: no
-
-  vars:
-    ansible_python_interpreter: '{{ virtualenv_interpreter }}'
-
-  vars_files:
-    - vars/main.yml
-
-  tasks:
     - vars:
         image: docker.io/python
         image_name: python
@@ -70,25 +58,31 @@
           - python
           - '-m'
           - http.server
+        namespace: idempotence-testing
       block:
+        - name: Create a namespace
+          community.okd.k8s:
+            name: '{{ namespace }}'
+            kind: Namespace
+            api_version: v1
+
         - name: Create imagestream
           community.okd.k8s:
-            namespace: testing
+            namespace: '{{ namespace }}'
             definition: '{{ okd_imagestream_template }}'
 
         - name: Create DeploymentConfig to reference ImageStream
           community.okd.k8s:
             name: '{{ k8s_pod_name }}'
-            namespace: testing
+            namespace: '{{ namespace }}'
             definition: '{{ okd_dc_template }}'
           vars:
             k8s_pod_name: is-idempotent-dc
 
-
         - name: Create Deployment to reference ImageStream
           community.okd.k8s:
             name: '{{ k8s_pod_name }}'
-            namespace: testing
+            namespace: '{{ namespace }}'
             definition: '{{ k8s_deployment_template | combine(metadata)  }}'
           vars:
             k8s_pod_annotations:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,6 +5,8 @@
   gather_facts: no
   vars:
     ansible_python_interpreter: '{{ virtualenv_interpreter }}'
+  vars_files:
+    - vars/main.yml
   tasks:
     # OpenShift Resources
     - name: Create a project
@@ -22,41 +24,78 @@
     - name: Create deployment config
       community.okd.k8s:
         state: present
-        inline: &dc
-          apiVersion: v1
-          kind: DeploymentConfig
-          metadata:
-            name: hello-world
-            labels:
-              app: galaxy
-              service: hello-world
-            namespace: testing
-          spec:
-            template:
-              metadata:
-                labels:
-                  app: galaxy
-                  service: hello-world
-              spec:
-                containers:
-                  - name: hello-world
-                    image: python
-                    command:
-                      - python
-                      - '-m'
-                      - http.server
-                    env:
-                      - name: TEST
-                        value: test
-            replicas: 1
-            strategy:
-              type: Recreate
+        name: hello-world
+        namespace: testing
+        definition: '{{ okd_dc_template }}'
         wait: yes
         wait_condition:
           type: Available
           status: True
+      vars:
+        k8s_pod_name: hello-world
+        k8s_pod_image: python
+        k8s_pod_command:
+          - python
+          - '-m'
+          - http.server
+        k8s_pod_env:
+          - name: TEST
+            value: test
+        okd_dc_triggers:
+          - type: ConfigChange
       register: output
 
     - name: Show output
       debug:
         var: output
+
+- name: Converge
+  hosts: localhost
+  connection: local
+  gather_facts: no
+
+  vars:
+    ansible_python_interpreter: '{{ virtualenv_interpreter }}'
+
+  vars_files:
+    - vars/main.yml
+
+  tasks:
+    - vars:
+        image: docker.io/python
+        image_name: python
+        image_tag: latest
+        k8s_pod_image: python
+        k8s_pod_command:
+          - python
+          - '-m'
+          - http.server
+      block:
+        - name: Create imagestream
+          k8s:
+            namespace: testing
+            definition: '{{ okd_imagestream_template }}'
+
+        - name: Create DeploymentConfig to reference ImageStream
+          k8s:
+            name: '{{ k8s_pod_name }}'
+            namespace: testing
+            definition: '{{ okd_dc_template }}'
+          vars:
+            k8s_pod_name: is-idempotent-dc
+
+
+        - name: Create Deployment to reference ImageStream
+          k8s:
+            name: '{{ k8s_pod_name }}'
+            namespace: testing
+            definition: '{{ k8s_deployment_template | combine(metadata)  }}'
+          vars:
+            k8s_pod_annotations:
+              "alpha.image.policy.openshift.io/resolve-names": "*"
+            k8s_pod_name: is-idempotent-deployment
+            metadata:
+              metadata:
+                annotations:
+                  image.openshift.io/triggers: |
+                      '[{"from":{"kind":"ImageStreamTag","name":"{{ image_name }}:{{ image_tag}}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"{{ k8s_pod_name }}\")].image"}]'

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -72,12 +72,12 @@
           - http.server
       block:
         - name: Create imagestream
-          k8s:
+          community.okd.k8s:
             namespace: testing
             definition: '{{ okd_imagestream_template }}'
 
         - name: Create DeploymentConfig to reference ImageStream
-          k8s:
+          community.okd.k8s:
             name: '{{ k8s_pod_name }}'
             namespace: testing
             definition: '{{ okd_dc_template }}'
@@ -86,7 +86,7 @@
 
 
         - name: Create Deployment to reference ImageStream
-          k8s:
+          community.okd.k8s:
             name: '{{ k8s_pod_name }}'
             namespace: testing
             definition: '{{ k8s_deployment_template | combine(metadata)  }}'
@@ -94,8 +94,12 @@
             k8s_pod_annotations:
               "alpha.image.policy.openshift.io/resolve-names": "*"
             k8s_pod_name: is-idempotent-deployment
+            annotation:
+              - from:
+                  kind: ImageStreamTag
+                  name: "{{ image_name }}:{{ image_tag}}}"
+                fieldPath: 'spec.template.spec.containers[?(@.name=="{{ k8s_pod_name }}")].image}'
             metadata:
               metadata:
                 annotations:
-                  image.openshift.io/triggers: |
-                      '[{"from":{"kind":"ImageStreamTag","name":"{{ image_name }}:{{ image_tag}}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"{{ k8s_pod_name }}\")].image"}]'
+                  image.openshift.io/triggers: '{{ annotation | to_json }}'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -29,7 +29,7 @@ provisioner:
         playbook_namespace: molecule-tests
   env:
     ANSIBLE_FORCE_COLOR: 'true'
-    ANSIBLE_COLLECTIONS_PATHS: ${MOLECULE_PROJECT_DIRECTORY}
+    ANSIBLE_COLLECTIONS_PATHS: ${OVERRIDE_COLLECTION_PATH:-$MOLECULE_PROJECT_DIRECTORY}
 verifier:
   name: ansible
   lint: |

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,6 +9,9 @@ platforms:
       - k8s
 provisioner:
   name: ansible
+  log: true
+  options:
+    vvv: True
   config_options:
     inventory:
       enable_plugins: community.okd.openshift

--- a/molecule/default/vars/main.yml
+++ b/molecule/default/vars/main.yml
@@ -1,0 +1,94 @@
+---
+k8s_pod_annotations: {}
+
+k8s_pod_metadata:
+  labels:
+    app: '{{ k8s_pod_name }}'
+  annotations: '{{ k8s_pod_annotations }}'
+
+k8s_pod_spec:
+  serviceAccount: "{{ k8s_pod_service_account }}"
+  containers:
+    - image: "{{ k8s_pod_image }}"
+      imagePullPolicy: Always
+      name: "{{ k8s_pod_name }}"
+      command: "{{ k8s_pod_command }}"
+      readinessProbe:
+        initialDelaySeconds: 15
+        exec:
+          command:
+            - /bin/true
+      resources: "{{ k8s_pod_resources }}"
+      ports: "{{ k8s_pod_ports }}"
+      env: "{{ k8s_pod_env }}"
+
+k8s_pod_service_account: default
+
+k8s_pod_resources:
+  limits:
+    cpu: "100m"
+    memory: "100Mi"
+
+k8s_pod_command: []
+
+k8s_pod_ports: []
+
+k8s_pod_env: []
+
+k8s_pod_template:
+  metadata: "{{ k8s_pod_metadata }}"
+  spec: "{{ k8s_pod_spec }}"
+
+k8s_deployment_spec:
+  template: '{{ k8s_pod_template }}'
+  selector:
+    matchLabels:
+      app: '{{ k8s_pod_name }}'
+  replicas: 1
+
+k8s_deployment_template:
+  apiVersion: apps/v1
+  kind: Deployment
+  spec: '{{ k8s_deployment_spec }}'
+
+okd_dc_triggers:
+  - type: ConfigChange
+  - type: ImageChange
+    imageChangeParams:
+      automatic: true
+      containerNames:
+        - '{{ k8s_pod_name }}'
+      from:
+        kind: ImageStreamTag
+        name: '{{ image_name }}:{{ image_tag }}'
+
+okd_dc_spec:
+  template: '{{ k8s_pod_template }}'
+  triggers: '{{ okd_dc_triggers }}'
+  replicas: 1
+  strategy:
+    type: Recreate
+
+okd_dc_template:
+  apiVersion: v1
+  kind: DeploymentConfig
+  spec: '{{ okd_dc_spec }}'
+
+okd_imagestream_template:
+  apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    name: '{{ image_name }}'
+  spec:
+    lookupPolicy:
+      local: true
+    tags:
+    - annotations: null
+      from:
+        kind: DockerImage
+        name: '{{ image }}'
+      name: '{{ image_tag }}'
+      referencePolicy:
+        type: Source
+
+image_tag: latest

--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -289,7 +289,7 @@ except ImportError:
     pass
 
 TRIGGER_ANNOTATION = 'image.openshift.io/triggers'
-TRIGGER_CONTAINER = re.compile(r"(?P<path>.*)\[((?P<index>[0-9]+)|\?\(@\.name==[\"'\\]*(?P<name>\w+))")
+TRIGGER_CONTAINER = re.compile(r"(?P<path>.*)\[((?P<index>[0-9]+)|\?\(@\.name==[\"'\\]*(?P<name>[a-z0-9]([-a-z0-9]*[a-z0-9])?))")
 
 
 class OKDRawModule(KubernetesRawModule):

--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -372,7 +372,7 @@ class OKDRawModule(KubernetesRawModule):
                     else:
                         existing_index = new_index = None
                     if existing_index is not None and new_index is not None:
-                        if len(existing_containers) < existing_index and len(new_containers) < new_index:
+                        if existing_index < len(existing_containers) and new_index < len(new_containers):
                             set_from_fields(definition, path + [new_index, 'image'], get_from_fields(existing, path + [existing_index, 'image']))
         return definition
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If deploymentconfigs are configured to trigger on image stream update don't try to replace image field
This should prevent infinite loops when managing these resources from an operator
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/k8s.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
