### PR TITLE
Add openshift_route module for route creation

### DIFF
--- a/molecule/default/tasks/openshift_route.yml
+++ b/molecule/default/tasks/openshift_route.yml
@@ -194,7 +194,7 @@
     namespace: default
     name: hello-kubernetes-https
     tls:
-      insecure_policy: disable
+      insecure_policy: disallow
     termination: edge
   register: route
 

--- a/molecule/default/tasks/openshift_route.yml
+++ b/molecule/default/tasks/openshift_route.yml
@@ -184,6 +184,8 @@
     termination: edge
   register: route
 
+- debug: var=route
+
 - name: Attempt to hit https URL
   uri:
     url: 'https://{{ route.result.spec.host }}'

--- a/molecule/default/tasks/openshift_route.yml
+++ b/molecule/default/tasks/openshift_route.yml
@@ -61,6 +61,13 @@
       - result.status == 200
       - result.content == 'Hello OpenShift!\n'
 
+- name: Delete route
+  community.okd.openshift_route:
+    name: '{{ route.result.metadata.name }}'
+    namespace: default
+    state: absent
+    wait: yes
+
 - name: Create Route with custom name and wait
   community.okd.openshift_route:
     service: hello-kubernetes
@@ -88,6 +95,13 @@
       - not result.redirected
       - result.status == 200
       - result.content == 'Hello OpenShift!\n'
+
+- name: Delete route
+  community.okd.openshift_route:
+    name: '{{ route.result.metadata.name }}'
+    namespace: default
+    state: absent
+    wait: yes
 
 - name: Create edge-terminated route that allows insecure traffic
   community.okd.openshift_route:
@@ -174,13 +188,13 @@
       - result.status == 200
       - result.content == 'Hello OpenShift!\n'
 
-- name: Alter edge-terminated route disallow
+- name: Alter edge-terminated route with insecure traffic disabled
   community.okd.openshift_route:
     service: hello-kubernetes
     namespace: default
     name: hello-kubernetes-https
     tls:
-      insecure_policy: null
+      insecure_policy: disable
     termination: edge
   register: route
 
@@ -217,3 +231,10 @@
     that:
       - not result.redirected
       - result.status == 503
+
+- name: Delete route
+  community.okd.openshift_route:
+    name: '{{ route.result.metadata.name }}'
+    namespace: default
+    state: absent
+    wait: yes

--- a/molecule/default/tasks/openshift_route.yml
+++ b/molecule/default/tasks/openshift_route.yml
@@ -20,9 +20,9 @@
           spec:
             containers:
             - name: hello-kubernetes
-              image: docker.io/nginxdemos/hello:plain-text
+              image: docker.io/openshift/hello-openshift
               ports:
-              - containerPort: 80
+              - containerPort: 8080
 
 - name: Create Service
   community.okd.k8s:
@@ -36,10 +36,9 @@
       spec:
         ports:
         - port: 80
-          targetPort: 80
+          targetPort: 8080
         selector:
           app: hello-kubernetes
-
 
 - name: Create Route with fewest possible arguments
   community.okd.openshift_route:
@@ -51,6 +50,8 @@
   uri:
     url: 'http://{{ route.result.spec.host }}'
     return_content: yes
+  until: result is successful
+  retries: 10
   register: result
 
 - name: Assert the page content is as expected
@@ -58,24 +59,22 @@
     that:
       - not result.redirected
       - result.status == 200
-      - "'hello-kubernetes' in (result.content | from_yaml)['Server name']"
+      - result.content == 'Hello OpenShift!\n'
 
 - name: Create Route with custom name and wait
   community.okd.openshift_route:
     service: hello-kubernetes
     namespace: default
     name: test1
-    # wait: yes
+    wait: yes
   register: route
 
-# - name: Assert that the condition is properly set
-#   assert:
-#     that:
-#       - route.duration is defined
-#       - route.result.status.conditions is defined
-#       - route.result.status.conditions.0 is defined
-#       - route.result.status.conditions.0.type == 'Admitted'
-#       - route.result.status.conditions.0.status == 'True'
+- name: Assert that the condition is properly set
+  assert:
+    that:
+      - route.duration is defined
+      - route.result.status.ingress.0.conditions.0.type == 'Admitted'
+      - route.result.status.ingress.0.conditions.0.status == 'True'
 
 - name: Attempt to hit http URL
   uri:
@@ -88,7 +87,7 @@
     that:
       - not result.redirected
       - result.status == 200
-      - "'hello-kubernetes' in (result.content | from_yaml)['Server name']"
+      - result.content == 'Hello OpenShift!\n'
 
 - name: Create edge-terminated route that allows insecure traffic
   community.okd.openshift_route:
@@ -104,6 +103,8 @@
   uri:
     url: 'http://{{ route.result.spec.host }}'
     return_content: yes
+  until: result is successful
+  retries: 10
   register: result
 
 - name: Assert the page content is as expected
@@ -111,13 +112,15 @@
     that:
       - not result.redirected
       - result.status == 200
-      - "'hello-kubernetes' in (result.content | from_yaml)['Server name']"
+      - result.content == 'Hello OpenShift!\n'
 
 - name: Attempt to hit https URL
   uri:
     url: 'https://{{ route.result.spec.host }}'
     validate_certs: no
     return_content: yes
+  until: result is successful
+  retries: 10
   register: result
 
 - name: Assert the page content is as expected
@@ -125,7 +128,7 @@
     that:
       - not result.redirected
       - result.status == 200
-      - "'hello-kubernetes' in (result.content | from_yaml)['Server name']"
+      - result.content == 'Hello OpenShift!\n'
 
 - name: Alter edge-terminated route to redirect insecure traffic
   community.okd.openshift_route:
@@ -142,6 +145,8 @@
     url: 'http://{{ route.result.spec.host }}'
     return_content: yes
     validate_certs: no
+  until: result is successful
+  retries: 10
   register: result
 
 - name: Assert the page content is as expected
@@ -149,13 +154,15 @@
     that:
       - result.redirected
       - result.status == 200
-      - "'hello-kubernetes' in (result.content | from_yaml)['Server name']"
+      - result.content == 'Hello OpenShift!\n'
 
 - name: Attempt to hit https URL
   uri:
     url: 'https://{{ route.result.spec.host }}'
     validate_certs: no
     return_content: yes
+  until: result is successful
+  retries: 10
   register: result
 
 - name: Assert the page content is as expected
@@ -163,7 +170,7 @@
     that:
       - not result.redirected
       - result.status == 200
-      - "'hello-kubernetes' in (result.content | from_yaml)['Server name']"
+      - result.content == 'Hello OpenShift!\n'
 
 - name: Alter edge-terminated route disallow
   community.okd.openshift_route:
@@ -180,6 +187,8 @@
     url: 'https://{{ route.result.spec.host }}'
     validate_certs: no
     return_content: yes
+  until: result is successful
+  retries: 10
   register: result
 
 - name: Assert the page content is as expected
@@ -187,13 +196,14 @@
     that:
       - not result.redirected
       - result.status == 200
-      - "'hello-kubernetes' in (result.content | from_yaml)['Server name']"
+      - result.content == 'Hello OpenShift!\n'
 
 - name: Attempt to hit http URL
   uri:
     url: 'http://{{ route.result.spec.host }}'
-    return_content: yes
     status_code: 503
+  until: result is successful
+  retries: 10
   register: result
 
 - debug: var=result
@@ -202,5 +212,4 @@
   assert:
     that:
       - not result.redirected
-      - result.status == 200
-      - "'hello-kubernetes' in (result.content | from_yaml)['Server name']"
+      - result.status == 503

--- a/molecule/default/tasks/openshift_route.yml
+++ b/molecule/default/tasks/openshift_route.yml
@@ -145,7 +145,9 @@
     url: 'http://{{ route.result.spec.host }}'
     return_content: yes
     validate_certs: no
-  until: result is successful
+  until:
+    - result is successful
+    - result.redirected
   retries: 10
   register: result
 

--- a/molecule/default/tasks/openshift_route.yml
+++ b/molecule/default/tasks/openshift_route.yml
@@ -20,9 +20,9 @@
           spec:
             containers:
             - name: hello-kubernetes
-              image: paulbouwer/hello-kubernetes:1.8
+              image: docker.io/nginxdemos/hello:plain-text
               ports:
-              - containerPort: 8080
+              - containerPort: 80
 
 - name: Create Service
   community.okd.k8s:
@@ -36,24 +36,171 @@
       spec:
         ports:
         - port: 80
-          targetPort: 8080
+          targetPort: 80
         selector:
           app: hello-kubernetes
 
-
-- name: Create Route
-  community.okd.openshift_route:
-    service: hello-kubernetes
-    namespace: default
-    name: test1
 
 - name: Create Route with fewest possible arguments
   community.okd.openshift_route:
     service: hello-kubernetes
     namespace: default
+  register: route
 
-- name: Create edge-terminated route
+- name: Attempt to hit http URL
+  uri:
+    url: 'http://{{ route.result.spec.host }}'
+    return_content: yes
+  register: result
+
+- name: Assert the page content is as expected
+  assert:
+    that:
+      - not result.redirected
+      - result.status == 200
+      - "'hello-kubernetes' in (result.content | from_yaml)['Server name']"
+
+- name: Create Route with custom name and wait
+  community.okd.openshift_route:
+    service: hello-kubernetes
+    namespace: default
+    name: test1
+    # wait: yes
+  register: route
+
+# - name: Assert that the condition is properly set
+#   assert:
+#     that:
+#       - route.duration is defined
+#       - route.result.status.conditions is defined
+#       - route.result.status.conditions.0 is defined
+#       - route.result.status.conditions.0.type == 'Admitted'
+#       - route.result.status.conditions.0.status == 'True'
+
+- name: Attempt to hit http URL
+  uri:
+    url: 'http://{{ route.result.spec.host }}'
+    return_content: yes
+  register: result
+
+- name: Assert the page content is as expected
+  assert:
+    that:
+      - not result.redirected
+      - result.status == 200
+      - "'hello-kubernetes' in (result.content | from_yaml)['Server name']"
+
+- name: Create edge-terminated route that allows insecure traffic
   community.okd.openshift_route:
     service: hello-kubernetes
     namespace: default
     name: hello-kubernetes-https
+    tls:
+      insecure_policy: allow
+    termination: edge
+  register: route
+
+- name: Attempt to hit http URL
+  uri:
+    url: 'http://{{ route.result.spec.host }}'
+    return_content: yes
+  register: result
+
+- name: Assert the page content is as expected
+  assert:
+    that:
+      - not result.redirected
+      - result.status == 200
+      - "'hello-kubernetes' in (result.content | from_yaml)['Server name']"
+
+- name: Attempt to hit https URL
+  uri:
+    url: 'https://{{ route.result.spec.host }}'
+    validate_certs: no
+    return_content: yes
+  register: result
+
+- name: Assert the page content is as expected
+  assert:
+    that:
+      - not result.redirected
+      - result.status == 200
+      - "'hello-kubernetes' in (result.content | from_yaml)['Server name']"
+
+- name: Alter edge-terminated route to redirect insecure traffic
+  community.okd.openshift_route:
+    service: hello-kubernetes
+    namespace: default
+    name: hello-kubernetes-https
+    tls:
+      insecure_policy: redirect
+    termination: edge
+  register: route
+
+- name: Attempt to hit http URL
+  uri:
+    url: 'http://{{ route.result.spec.host }}'
+    return_content: yes
+    validate_certs: no
+  register: result
+
+- name: Assert the page content is as expected
+  assert:
+    that:
+      - result.redirected
+      - result.status == 200
+      - "'hello-kubernetes' in (result.content | from_yaml)['Server name']"
+
+- name: Attempt to hit https URL
+  uri:
+    url: 'https://{{ route.result.spec.host }}'
+    validate_certs: no
+    return_content: yes
+  register: result
+
+- name: Assert the page content is as expected
+  assert:
+    that:
+      - not result.redirected
+      - result.status == 200
+      - "'hello-kubernetes' in (result.content | from_yaml)['Server name']"
+
+- name: Alter edge-terminated route disallow
+  community.okd.openshift_route:
+    service: hello-kubernetes
+    namespace: default
+    name: hello-kubernetes-https
+    tls:
+      insecure_policy: null
+    termination: edge
+  register: route
+
+- name: Attempt to hit https URL
+  uri:
+    url: 'https://{{ route.result.spec.host }}'
+    validate_certs: no
+    return_content: yes
+  register: result
+
+- name: Assert the page content is as expected
+  assert:
+    that:
+      - not result.redirected
+      - result.status == 200
+      - "'hello-kubernetes' in (result.content | from_yaml)['Server name']"
+
+- name: Attempt to hit http URL
+  uri:
+    url: 'http://{{ route.result.spec.host }}'
+    return_content: yes
+    status_code: 503
+  register: result
+
+- debug: var=result
+
+- name: Assert the page content is as expected
+  assert:
+    that:
+      - not result.redirected
+      - result.status == 200
+      - "'hello-kubernetes' in (result.content | from_yaml)['Server name']"

--- a/molecule/default/tasks/openshift_route.yml
+++ b/molecule/default/tasks/openshift_route.yml
@@ -1,0 +1,59 @@
+---
+- name: Create Deployment
+  community.okd.k8s:
+    wait: yes
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: hello-kubernetes
+        namespace: default
+      spec:
+        replicas: 3
+        selector:
+          matchLabels:
+            app: hello-kubernetes
+        template:
+          metadata:
+            labels:
+              app: hello-kubernetes
+          spec:
+            containers:
+            - name: hello-kubernetes
+              image: paulbouwer/hello-kubernetes:1.8
+              ports:
+              - containerPort: 8080
+
+- name: Create Service
+  community.okd.k8s:
+    wait: yes
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: hello-kubernetes
+        namespace: default
+      spec:
+        ports:
+        - port: 80
+          targetPort: 8080
+        selector:
+          app: hello-kubernetes
+
+
+- name: Create Route
+  community.okd.openshift_route:
+    service: hello-kubernetes
+    namespace: default
+    name: test1
+
+- name: Create Route with fewest possible arguments
+  community.okd.openshift_route:
+    service: hello-kubernetes
+    namespace: default
+
+- name: Create edge-terminated route
+  community.okd.openshift_route:
+    service: hello-kubernetes
+    namespace: default
+    name: hello-kubernetes-https

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -61,3 +61,4 @@
     - import_tasks: tasks/validate_not_installed.yml
 
     - import_tasks: tasks/openshift_auth.yml
+    - import_tasks: tasks/openshift_route.yml

--- a/plugins/modules/openshift_expose.py
+++ b/plugins/modules/openshift_expose.py
@@ -1,0 +1,209 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2020, Red Hat
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+module: openshift_expose
+
+short_description: Expose a Service as an OpenShift Route.
+
+version_added: "1.1.0"
+
+author: "Fabian von Feilitzsch (@fabianvf)"
+
+description:
+  - Looks up a Service and creates a new Route based on it.
+  - Analogous to `oc expose` for creating Routes, but does not support creating Services.
+  - For creating Services from other resources, see community.kubernetes.k8s_expose
+
+extends_documentation_fragment:
+  - community.kubernetes.k8s_auth_options
+  - community.kubernetes.k8s_wait_options
+
+requirements:
+  - "python >= 2.7"
+  - "openshift >= 0.11.0"
+  - "PyYAML >= 3.11"
+
+options:
+  service:
+    description:
+      - The name of the service to expose.
+    type: str
+    required: yes
+    aliases: ['svc']
+  namespace:
+    description:
+      - The namespace of the resource being targeted.
+      - The Route will be created in this namespace as well.
+    required: yes
+    type: str
+  labels:
+    description:
+      - Specify the labels to apply to the created Route.
+      - 'A set of key: value pairs.'
+    type: dict
+  name:
+    description:
+      - The desired name of the Route to be created.
+      - Defaults to the value of I(service)
+    type: str
+  hostname:
+    description:
+      - The hostname for the Route.
+    type: str
+  path:
+    description:
+      - The path for the Route
+    type: str
+  wildcard_policy:
+    description:
+      - The wildcard policy for the hostname.
+    choices:
+      - None
+      - Subdomain
+    default: None
+    type: str
+  port:
+    description:
+      - Name or number of the port the Route will route traffic to.
+    type: str
+  tls:
+    description:
+      - TLS configuration for the newly created route.
+    type: object
+    contains:
+      ca_certificate:
+        description:
+          - Path to a CA certificate file on the target host.
+        type: str
+      certificate:
+        description:
+          - Path to a certificate file on the target host.
+        type: str
+      destination_ca_certificate:
+        description:
+          - Path to a CA certificate file used for securing the connection.
+          - Defaults to the Service CA
+        type: str
+      key:
+        description:
+          - Path to a key file on the target host.
+        type: str
+      insecure_policy:
+        description:
+          - Sets the InsecureEdgeTerminationPolicy for the Route.
+        type: str
+        choices:
+          - Allow
+          - Disable
+          - Redirect
+        default: Disable
+      termination:
+        description:
+          - The termination type of the Route.
+        choices:
+          - Edge
+          - Passthrough
+          - Reencrypt
+        default: Edge
+'''
+
+EXAMPLES = r'''
+- name: Create a Service for an nginx deployment that connects port 80 to port 8000 in the container
+  community.okd.openshift_expose:
+    deployment: nginx
+    namespace: default
+    port: '80'
+    target_port: '8000'
+  register: nginx_service
+
+- name: Create a second service based on the above service, that connects port 443 to port 8443 in the container
+  community.okd.openshift_expose:
+    service: '{{ nginx_service.result.metadata.name }}'
+    namespace: default
+    port: '443'
+    target_port: '8443'
+    name: nginx-https
+
+- name: Create a service for a pod
+  community.okd.openshift_expose:
+    pod: hello-world
+    namespace: default
+    name: hello-world
+'''
+
+RETURN = r'''
+result:
+  description:
+  - The Route object that was created or updated
+  returned: success
+  type: complex
+  contains:
+    metadata:
+      type: complex
+    spec:
+      type: complex
+    status:
+      type: complex
+'''
+
+import copy
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.kubernetes.plugins.module_utils.common import (
+    K8sAnsibleMixin, AUTH_ARG_SPEC, WAIT_ARG_SPEC
+)
+
+
+class OpenShiftExpose(K8sAnsibleMixin):
+
+    def __init__(self):
+        self.module = AnsibleModule(
+            argument_spec=self.argspec,
+            supports_check_mode=True,
+        )
+        self.params = self.module.params
+        self.fail_json = self.module.fail_json
+        super(OpenShiftExpose, self).__init__()
+
+    @property
+    def argspec(self):
+        spec = copy.deepcopy(AUTH_ARG_SPEC)
+        spec.update(copy.deepcopy(WAIT_ARG_SPEC))
+
+        spec['service'] = dict(type='str', required=True, aliases=['svc'])
+        spec['namespace'] = dict(required=True, type='str')
+        spec['labels'] = dict(type='dict')
+        spec['name'] = dict(type='str')
+        spec['hostname'] = dict(type='str')
+        spec['path'] = dict(type='str')
+        spec['wildcard_policy'] = dict(choices=['None', 'Subdomain'], default=None, type='str')
+        spec['port'] = dict(type='str')
+        spec['tls'] = dict(type='object', contains=dict(
+            ca_certificate=dict(type='str'),
+            certificate=dict(type='str'),
+            destination_ca_certificate=dict(type='str'),
+            key=dict(type='str'),
+            insecure_policy=dict(type='str', choices=['Allow', 'Disable', 'Redirect'], default='Disable'),
+            termination=dict(choices=['Edge', 'Passthrough', 'Reencrypt'], default='Edge'),
+        )
+        return spec
+
+    def execute_module(self):
+        raise NotImplementedError
+
+
+def main():
+    OpenShiftExpose().execute_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/openshift_route.py
+++ b/plugins/modules/openshift_route.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 
 DOCUMENTATION = r'''
-module: openshift_expose
+module: openshift_route
 
 short_description: Expose a Service as an OpenShift Route.
 
@@ -20,7 +20,7 @@ author: "Fabian von Feilitzsch (@fabianvf)"
 
 description:
   - Looks up a Service and creates a new Route based on it.
-  - Analogous to `oc expose` for creating Routes, but does not support creating Services.
+  - Analogous to `oc expose` and `oc create route` for creating Routes, but does not support creating Services.
   - For creating Services from other resources, see community.kubernetes.k8s_expose
 
 extends_documentation_fragment:
@@ -163,7 +163,7 @@ EXAMPLES = r'''
           app: hello-kubernetes
 
 - name: Expose the insecure hello-world service externally
-  community.okd.openshift_expose:
+  community.okd.openshift_route:
     service: hello-kubernetes
     namespace: default
     insecure_policy: allow
@@ -198,7 +198,7 @@ from ansible_collections.community.kubernetes.plugins.module_utils.common import
 )
 
 
-class OpenShiftExpose(K8sAnsibleMixin):
+class OpenShiftRoute(K8sAnsibleMixin):
 
     def __init__(self):
         self.module = AnsibleModule(
@@ -213,7 +213,7 @@ class OpenShiftExpose(K8sAnsibleMixin):
         self.check_mode = self.module.check_mode
         self.warnings = []
         self.params['merge_type'] = None
-        super(OpenShiftExpose, self).__init__()
+        super(OpenShiftRoute, self).__init__()
 
     @property
     def argspec(self):
@@ -339,7 +339,7 @@ class OpenShiftExpose(K8sAnsibleMixin):
 
 
 def main():
-    OpenShiftExpose().execute_module()
+    OpenShiftRoute().execute_module()
 
 
 if __name__ == '__main__':

--- a/plugins/modules/openshift_route.py
+++ b/plugins/modules/openshift_route.py
@@ -230,8 +230,6 @@ class OpenShiftRoute(K8sAnsibleMixin):
             supports_check_mode=True,
         )
         self.params = self.module.params
-        self.fail_json = self.module.fail_json
-
         # TODO: should probably make it so that at least some of these aren't required for perform_action to work
         # Or at least explicitly pass them in
         self.append_hash = False
@@ -239,6 +237,10 @@ class OpenShiftRoute(K8sAnsibleMixin):
         self.check_mode = self.module.check_mode
         self.warnings = []
         self.params['merge_type'] = None
+
+    @property
+    def fail_json(self):
+        return self.module.fail_json
 
     @property
     def argspec(self):

--- a/plugins/modules/openshift_route.py
+++ b/plugins/modules/openshift_route.py
@@ -113,7 +113,7 @@ options:
         choices:
           - allow
           - redirect
-          - disable
+          - disallow
   termination:
     description:
       - The termination type of the Route.
@@ -124,6 +124,7 @@ options:
       - passthrough
       - reencrypt
       - insecure
+    default: insecure
     type: str
 '''
 
@@ -365,9 +366,9 @@ class OpenShiftRoute(K8sAnsibleMixin):
             certificate=dict(type='str'),
             destination_ca_certificate=dict(type='str'),
             key=dict(type='str'),
-            insecure_policy=dict(type='str', choices=['allow', 'redirect', 'disable']),
+            insecure_policy=dict(type='str', choices=['allow', 'redirect', 'disallow']),
         ))
-        spec['termination'] = dict(choices=['edge', 'passthrough', 'reencrypt', 'insecure'])
+        spec['termination'] = dict(choices=['edge', 'passthrough', 'reencrypt', 'insecure'], default='insecure')
 
         return spec
 
@@ -404,7 +405,7 @@ class OpenShiftRoute(K8sAnsibleMixin):
             tls_dest_ca_cert = self.params['tls'].get('destination_ca_certificate')
             tls_key = self.params['tls'].get('key')
             tls_insecure_policy = self.params['tls'].get('insecure_policy')
-            if tls_insecure_policy == 'disable':
+            if tls_insecure_policy == 'disallow':
                 tls_insecure_policy = None
         else:
             tls_ca_cert = tls_cert = tls_dest_ca_cert = tls_key = tls_insecure_policy = None

--- a/plugins/modules/openshift_route.py
+++ b/plugins/modules/openshift_route.py
@@ -208,6 +208,8 @@ except ImportError:
 class OpenShiftRoute(K8sAnsibleMixin):
 
     def __init__(self):
+        super(OpenShiftRoute, self).__init__()
+
         self.module = AnsibleModule(
             argument_spec=self.argspec,
             supports_check_mode=True,

--- a/plugins/modules/openshift_route.py
+++ b/plugins/modules/openshift_route.py
@@ -114,6 +114,7 @@ options:
           - allow
           - redirect
           - disallow
+        default: disallow
   termination:
     description:
       - The termination type of the Route.
@@ -366,7 +367,7 @@ class OpenShiftRoute(K8sAnsibleMixin):
             certificate=dict(type='str'),
             destination_ca_certificate=dict(type='str'),
             key=dict(type='str'),
-            insecure_policy=dict(type='str', choices=['allow', 'redirect', 'disallow']),
+            insecure_policy=dict(type='str', choices=['allow', 'redirect', 'disallow'], default='disallow'),
         ))
         spec['termination'] = dict(choices=['edge', 'passthrough', 'reencrypt', 'insecure'], default='insecure')
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds a new openshift_route module, which handles creating routes from services. Parameters and functionality are an amalgamation of `oc expose` and `oc create route`.

Fixes #31 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
openshift_route
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
