### PR TITLE
Fix doc string

### DIFF
--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -134,7 +134,7 @@ options:
       will only work if the same object is passed with state=absent (alternatively, just use state=absent with the name including
       the generated hash and append_hash=no)
     type: bool
-    default: False
+    default: false
   apply:
     description:
     - C(apply) compares the desired resource definition with the previously supplied resource definition,
@@ -142,7 +142,7 @@ options:
     - C(apply) works better with Services than 'force=yes'
     - mutually exclusive with C(merge_type)
     type: bool
-    default: False
+    default: false
 
 requirements:
   - "python >= 2.7"

--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -134,6 +134,7 @@ options:
       will only work if the same object is passed with state=absent (alternatively, just use state=absent with the name including
       the generated hash and append_hash=no)
     type: bool
+    default: False
   apply:
     description:
     - C(apply) compares the desired resource definition with the previously supplied resource definition,
@@ -141,6 +142,7 @@ options:
     - C(apply) works better with Services than 'force=yes'
     - mutually exclusive with C(merge_type)
     type: bool
+    default: False
 
 requirements:
   - "python >= 2.7"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The sanity tests fail due to missing default values on a few options in
the doc string. This change puts the doc string in alignment with the
argument spec.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I think either a dependency change or a configuration change may have happened upstream in ansible test to cause this to start failing now.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
