### PR TITLE
Remove has_action field from doc fragment

### DIFF
--- a/ci/downstream_fragments.py
+++ b/ci/downstream_fragments.py
@@ -13,6 +13,7 @@ with open("./rendereddocfragments.txt", 'w') as df_fd:
 
         json_docs[sys.argv[1]]['doc'].pop('collection', '')
         json_docs[sys.argv[1]]['doc'].pop('filename', '')
+        json_docs[sys.argv[1]]['doc'].pop('has_action', '')
 
         df_fd.write("DOCUMENTATION = '''\n")
         df_fd.write(yaml.dump(json_docs[sys.argv[1]]['doc'], default_flow_style=False))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A recent change in Ansible
(https://github.com/ansible/ansible/commit/42da4807214cd609fd3c1800ab245c025ae044cd)
added a has_action field to the json output of ansible-doc. This started
causing the downstream sanity checks to fail.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
collection

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
