### PR TITLE
Fix sanity failure

### DIFF
--- a/changelogs/fragments/77-fix-ci-failure.yaml
+++ b/changelogs/fragments/77-fix-ci-failure.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - restrict molecule version to <3.3.0 to address breaking change (https://github.com/ansible-collections/community.okd/pull/77).
+  - openshift_route - default to ``no_log=False`` for the ``key`` parameter in TLS configuration to fix sanity failures (https://github.com/ansible-collections/community.okd/pull/77).

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -18,7 +18,7 @@ RUN yum install -y \
  && pip3 install --no-cache-dir \
       openshift \
       ansible==2.9.* \
-      molecule \
+      "molecule<3.3.0" \
   && yum clean all \
   && rm -rf $HOME/.cache \
   && curl -L https://github.com/openshift/okd/releases/download/4.5.0-0.okd-2020-08-12-020541/openshift-client-linux-4.5.0-0.okd-2020-08-12-020541.tar.gz | tar -xz -C /usr/local/bin

--- a/plugins/modules/openshift_route.py
+++ b/plugins/modules/openshift_route.py
@@ -367,7 +367,7 @@ class OpenShiftRoute(K8sAnsibleMixin):
             ca_certificate=dict(type='str'),
             certificate=dict(type='str'),
             destination_ca_certificate=dict(type='str'),
-            key=dict(type='str'),
+            key=dict(type='str', no_log=False),
             insecure_policy=dict(type='str', choices=['allow', 'redirect', 'disallow'], default='disallow'),
         ))
         spec['termination'] = dict(choices=['edge', 'passthrough', 'reencrypt', 'insecure'], default='insecure')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fixes a sanity test failure for newer versions of ansible-test. It
was falsely flagging the key parameter for TLS configuration as
sensitive. This parameter is just the path to a key file.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
openshift_route

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
