### PR TITLE
Update CI for ansible 2.11

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -24,6 +24,7 @@ jobs:
         ansible:
           - stable-2.9
           - stable-2.10
+          - stable-2.11
           - devel
         python:
           - 2.7

--- a/changelogs/fragments/80-update-ci.yaml
+++ b/changelogs/fragments/80-update-ci.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - update CI to work with ansible 2.11 (https://github.com/ansible-collections/community.okd/pull/80).

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,0 +1,3 @@
+plugins/modules/k8s.py validate-modules:parameter-type-not-in-doc
+plugins/modules/k8s.py validate-modules:return-syntax-error
+plugins/modules/openshift_process.py validate-modules:parameter-type-not-in-doc


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This copies the ignore-2.11.txt to ignore-2.12.txt and makes sure the CI
build tests against ansible 2.11.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
N/A
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
