### PR TITLE
Removed old changelog fragments

### DIFF
--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -3,7 +3,7 @@ changelog_filename_template: ../CHANGELOG.rst
 changelog_filename_version_depth: 0
 changes_file: changelog.yaml
 changes_format: combined
-keep_fragments: true
+keep_fragments: false
 mention_ancestor: true
 new_plugins_after_name: removed_features
 notesdir: fragments

--- a/changelogs/fragments/1-initial-content.yml
+++ b/changelogs/fragments/1-initial-content.yml
@@ -1,3 +1,0 @@
----
-major_changes:
-  - Initial content migration from community.kubernetes (https://github.com/ansible-collections/community.okd/pull/3).

--- a/changelogs/fragments/11-dockerfile-tests.yml
+++ b/changelogs/fragments/11-dockerfile-tests.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - Dockerfile now is properly set up to run tests in a rootless container (https://github.com/ansible-collections/community.okd/pull/11).

--- a/changelogs/fragments/12-dockerfile-tests.yml
+++ b/changelogs/fragments/12-dockerfile-tests.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - Docker container can run as an arbitrary user (https://github.com/ansible-collections/community.okd/pull/12).

--- a/changelogs/fragments/13-makefile-tests.yml
+++ b/changelogs/fragments/13-makefile-tests.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - Add incluster Makefile target for CI (https://github.com/ansible-collections/community.okd/pull/13).

--- a/changelogs/fragments/15-ci-documentation.yml
+++ b/changelogs/fragments/15-ci-documentation.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - CI Documentation for working with Prow (https://github.com/ansible-collections/community.okd/pull/15).

--- a/changelogs/fragments/16-inventory-plugin-tests.yml
+++ b/changelogs/fragments/16-inventory-plugin-tests.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - Add tests for inventory plugin (https://github.com/ansible-collections/community.okd/pull/16).

--- a/changelogs/fragments/18-openshift-connection-plugin.yml
+++ b/changelogs/fragments/18-openshift-connection-plugin.yml
@@ -1,3 +1,0 @@
----
-major_changes:
-  - Add openshift connection plugin, update inventory plugin to use it (https://github.com/ansible-collections/community.okd/pull/18).

--- a/changelogs/fragments/20-downstream-build-scripts.yml
+++ b/changelogs/fragments/20-downstream-build-scripts.yml
@@ -1,3 +1,0 @@
----
-major_changes:
-  - Add downstream build scripts to build redhat.openshift (https://github.com/ansible-collections/community.okd/pull/20).

--- a/changelogs/fragments/27-route-api-group.yml
+++ b/changelogs/fragments/27-route-api-group.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - Use the API Group APIVersion for the `Route` object (https://github.com/ansible-collections/community.okd/pull/27).

--- a/changelogs/fragments/33-add-k8s_auth.yml
+++ b/changelogs/fragments/33-add-k8s_auth.yml
@@ -1,3 +1,0 @@
----
-major_changes:
-  - openshift_auth - new module (migrated from k8s_auth in community.kubernetes) (https://github.com/ansible-collections/community.okd/pull/33).

--- a/changelogs/fragments/36-contribution-guide.yml
+++ b/changelogs/fragments/36-contribution-guide.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - Add a contribution guide (https://github.com/ansible-collections/community.okd/pull/37).

--- a/changelogs/fragments/40-openshift_route.yml
+++ b/changelogs/fragments/40-openshift_route.yml
@@ -1,3 +1,0 @@
----
-major_changes:
-  - Add openshift_route module for creating routes from services (https://github.com/ansible-collections/community.okd/pull/40).

--- a/changelogs/fragments/44-openshift_process.yml
+++ b/changelogs/fragments/44-openshift_process.yml
@@ -1,3 +1,0 @@
----
-major_changes:
-  - Add openshift_process module for template rendering and optional application of rendered resources (https://github.com/ansible-collections/community.okd/pull/44).

--- a/changelogs/fragments/51-redhat-openshift-ah-release.yml
+++ b/changelogs/fragments/51-redhat-openshift-ah-release.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - Released version 1 to Automation Hub as redhat.openshift (https://github.com/ansible-collections/community.okd/issues/51).

--- a/changelogs/fragments/59-downstream-docs.yml
+++ b/changelogs/fragments/59-downstream-docs.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - Generate downstream redhat.openshift documentation (https://github.com/ansible-collections/community.okd/pull/59).

--- a/changelogs/fragments/7-molecule-tests.yml
+++ b/changelogs/fragments/7-molecule-tests.yml
@@ -1,3 +1,0 @@
----
-major_changes:
-  - Add custom k8s module, integrate better Molecule tests (https://github.com/ansible-collections/community.okd/pull/7).

--- a/changelogs/fragments/8-stale-bot.yml
+++ b/changelogs/fragments/8-stale-bot.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - Integrate stale bot for issue queue maintenance (https://github.com/ansible-collections/community.okd/pull/14).


### PR DESCRIPTION
##### SUMMARY

* Removed old changelog fragment files
* Updated configuration to remove old fragment files
  on release

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/config.yaml
changelogs/fragments/1-initial-content.yml
changelogs/fragments/11-dockerfile-tests.yml
changelogs/fragments/12-dockerfile-tests.yml
changelogs/fragments/13-makefile-tests.yml
changelogs/fragments/15-ci-documentation.yml
changelogs/fragments/16-inventory-plugin-tests.yml
changelogs/fragments/18-openshift-connection-plugin.yml
changelogs/fragments/20-downstream-build-scripts.yml
changelogs/fragments/27-route-api-group.yml
changelogs/fragments/33-add-k8s_auth.yml
changelogs/fragments/36-contribution-guide.yml
changelogs/fragments/40-openshift_route.yml
changelogs/fragments/44-openshift_process.yml
changelogs/fragments/51-redhat-openshift-ah-release.yml
changelogs/fragments/59-downstream-docs.yml
changelogs/fragments/7-molecule-tests.yml
changelogs/fragments/8-stale-bot.yml
