### PR TITLE
openshift_process fails with template does not contains message

### DIFF
--- a/changelogs/fragments/87-openshift_process-fix-template-without-message.yaml
+++ b/changelogs/fragments/87-openshift_process-fix-template-without-message.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - openshift_process - fix module execution when template does not include a message (https://github.com/ansible-collections/community.okd/pull/87).

--- a/molecule/default/files/pod-template.yaml
+++ b/molecule/default/files/pod-template.yaml
@@ -21,9 +21,3 @@ parameters:
   - name: NAME 
     description: trailing name of the pod
     required: true
-
-
-
-
-
-

--- a/molecule/default/files/pod-template.yaml
+++ b/molecule/default/files/pod-template.yaml
@@ -13,7 +13,7 @@ objects:
       - args:
         - /bin/sh
         - -c
-        - while true; do echo $(date); sleep 10; done
+        - while true; do echo $(date); sleep 15; done
         image: python:3.7-alpine
         imagePullPolicy: Always
         name: python

--- a/molecule/default/files/pod-template.yaml
+++ b/molecule/default/files/pod-template.yaml
@@ -1,0 +1,29 @@
+---
+kind: Template
+apiVersion: template.openshift.io/v1
+metadata:
+  name: pod-template
+objects:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: "Pod-${{ NAME }}"
+    spec:
+      containers:
+      - args:
+        - /bin/sh
+        - -c
+        - while true; do echo $(date); sleep 10; done
+        image: python:3.7-alpine
+        imagePullPolicy: Always
+        name: python
+parameters:
+  - name: NAME 
+    description: trailing name of the pod
+    required: true
+
+
+
+
+
+

--- a/molecule/default/tasks/openshift_process.yml
+++ b/molecule/default/tasks/openshift_process.yml
@@ -167,10 +167,7 @@
 - name: create template with file {{ files_dir }}/pod-template.yaml
   kubernetes.core.k8s:
     namespace: process-test
-    template: 
-      path: "{{ files_dir }}/pod-template.yaml"
-      variable_start_string: '[['
-      variable_end_string: ']]'
+    src:  "{{ files_dir }}/pod-template.yaml"
     state: present
 
 - name: Process pod template

--- a/molecule/default/tasks/openshift_process.yml
+++ b/molecule/default/tasks/openshift_process.yml
@@ -162,3 +162,25 @@
 
 - assert:
     that: result is not changed
+
+# Processing template without message
+- name: create template with file {{ files_dir }}/pod-template.yaml
+  kubernetes.core.k8s:
+    namespace: process-test
+    template: 
+      path: "{{ files_dir }}/pod-template.yaml"
+      variable_start_string: '[['
+      variable_end_string: ']]'
+    state: present
+
+- name: Process pod template
+  community.okd.openshift_process:
+    name: pod-template
+    namespace: process-test
+    state: rendered
+    parameters:
+      NAME: ansible
+  register: rendered_template
+
+- assert:
+    that: rendered_template.message == ""

--- a/plugins/modules/openshift_process.py
+++ b/plugins/modules/openshift_process.py
@@ -330,7 +330,6 @@ class OpenShiftProcess(K8sAnsibleMixin):
         except Exception as exc:
             self.module.fail_json(msg="Server failed to render the Template: {0}".format(to_native(exc)),
                                   error='', status='', reason='')
-        
         result['message'] = ""
         if "message" in response:
           result['message'] = response['message']

--- a/plugins/modules/openshift_process.py
+++ b/plugins/modules/openshift_process.py
@@ -332,7 +332,7 @@ class OpenShiftProcess(K8sAnsibleMixin):
                                   error='', status='', reason='')
         result['message'] = ""
         if "message" in response:
-          result['message'] = response['message']
+            result['message'] = response['message']
         result['resources'] = response['objects']
 
         if state != 'rendered':

--- a/plugins/modules/openshift_process.py
+++ b/plugins/modules/openshift_process.py
@@ -330,8 +330,10 @@ class OpenShiftProcess(K8sAnsibleMixin):
         except Exception as exc:
             self.module.fail_json(msg="Server failed to render the Template: {0}".format(to_native(exc)),
                                   error='', status='', reason='')
-
-        result['message'] = response['message']
+        
+        result['message'] = ""
+        if "message" in response:
+          result['message'] = response['message']
         result['resources'] = response['objects']
 
         if state != 'rendered':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
``openshift_process`` module is expecting a ``message`` field to be part of the template definition, when this is not the case the module execution fails.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #86 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
openshift_process
