### PR TITLE
Clean up CI build

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -27,11 +27,8 @@ jobs:
           - stable-2.11
           - devel
         python:
-          - 2.7
           - 3.7
           - 3.8
-        exclude:
-          - python: 3.8  # blocked by ansible/ansible#70155
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -52,73 +49,20 @@ jobs:
       # The docker container has all the pinned dependencies that are required.
       # Explicitly specify the version of Python we want to test
       - name: Run sanity tests
-        run: make upstream-test-sanity TEST_ARGS='--python ${{ matrix.python }}'
+        run: make upstream-test-sanity PYTHON_VERSION='${{ matrix.python }}'
         working-directory: ./ansible_collections/community/okd
 
-###
-# Integration tests (RECOMMENDED)
-#
-# https://docs.ansible.com/ansible/latest/dev_guide/testing_integration.html
-
-  # integration:
-  #   runs-on: ubuntu-latest
-  #   name: Integration (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }}})
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       ansible:
-  #         - stable-2.9
-  #         - stable-2.10
-  #         - devel
-  #       python:
-  #         - 2.7
-  #         - 3.7
-  #         - 3.8
-  #       exclude:
-  #         - python: 3.8  # blocked by ansible/ansible#70155
-
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v2
-  #       with:
-  #         path: ansible_collections/community/okd
-
-  #     - name: Set up Python ${{ matrix.ansible }}
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: ${{ matrix.python }}
-
-  #     - name: Install ansible-base (${{ matrix.ansible }})
-  #       run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
-
-  #     # OPTIONAL If your integration test requires Python libraries or modules from other collections
-  #     # Install them like this
-  #     - name: Install collection dependencies
-  #       run: ansible-galaxy collection install kubernetes.core -p .
-
-  #     # Run the integration tests
-  #     - name: Run integration test
-  #       run: ansible-test integration -v --color --retry-on-error --continue-on-error --diff --python ${{ matrix.python }} --docker --coverage
-  #       working-directory: ./ansible_collections/community/okd
-
-  #     # ansible-test support producing code coverage date
-  #     - name: Generate coverage report
-  #       run: ansible-test coverage xml -v --requirements --group-by command --group-by version
-  #       working-directory: ./ansible_collections/community/okd
-
-  #     # See the reports at https://codecov.io/gh/ansible_collections/GITHUBORG/REPONAME
-  #     - uses: codecov/codecov-action@v1
-  #       with:
-  #         fail_ci_if_error: false
-  #
   downstream-sanity-29:
     name: Downstream Sanity (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
     strategy:
       matrix:
         ansible:
           - stable-2.9
+          - stable-2.10
+          - stable-2.11
         python:
-          - 3.6
+          - 3.7
+          - 3.8
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -131,12 +75,13 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Install ansible 2.9
-        run: pip install "ansible>=2.9.0,<2.10.0"
+      # Install the head of the given branch (devel, stable-2.10)
+      - name: Install ansible-base (${{ matrix.ansible }})
+        run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
       # run ansible-test sanity inside of Docker.
       # The docker container has all the pinned dependencies that are required.
       # Explicitly specify the version of Python we want to test
       - name: Run sanity tests
-        run: make downstream-test-sanity
+        run: make downstream-test-sanity PYTHON_VERSION='${{ matrix.python }}'
         working-directory: ./ansible_collections/community/okd

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 VERSION = 1.1.2
 
 TEST_ARGS ?= ""
-PYTHON_VERSION ?= `python -c 'import platform; print("{0}.{1}".format(platform.python_version_tuple()[0], platform.python_version_tuple()[1]))'`
+PYTHON_VERSION ?= `python3 -c 'import platform; print("{0}.{1}".format(platform.python_version_tuple()[0], platform.python_version_tuple()[1]))'`
 
 clean:
 	rm -f community-okd-$(VERSION).tar.gz

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Also needs to be updated in galaxy.yml
 VERSION = 1.1.2
 
-TEST_ARGS ?= --docker --color
+SANITY_TEST_ARGS ?= --docker --color
 PYTHON_VERSION ?= `python3 -c 'import platform; print("{0}.{1}".format(platform.python_version_tuple()[0], platform.python_version_tuple()[1]))'`
 
 clean:
@@ -18,7 +18,7 @@ install: build
 	ansible-galaxy collection install -p ansible_collections community-okd-$(VERSION).tar.gz
 
 sanity: install
-	cd ansible_collections/community/okd && ansible-test sanity -v --python $(PYTHON_VERSION) $(TEST_ARGS)
+	cd ansible_collections/community/okd && ansible-test sanity -v --python $(PYTHON_VERSION) $(SANITY_TEST_ARGS)
 
 molecule:
 	molecule test

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ install: build
 sanity: install
 	cd ansible_collections/community/okd && ansible-test sanity -v --python $(PYTHON_VERSION) $(SANITY_TEST_ARGS)
 
-molecule:
+molecule: install
 	molecule test
 
 test-integration: upstream-test-integration downstream-test-integration

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,38 @@
+.PHONY: molecule
+
 # Also needs to be updated in galaxy.yml
 VERSION = 1.1.2
 
-# To run sanity tests in a venv, set SANITY_TEST_ARGS to '--venv'
-SANITY_TEST_ARGS ?= --docker --color
+TEST_ARGS ?= ""
+PYTHON_VERSION ?= `python -c 'import platform; print("{0}.{1}".format(platform.python_version_tuple()[0], platform.python_version_tuple()[1]))'`
 
 clean:
 	rm -f community-okd-$(VERSION).tar.gz
+	rm -f redhat-openshift-$(VERSION).tar.gz
 	rm -rf ansible_collections
 
 build: clean
 	ansible-galaxy collection build
 
-install-kubernetes-src:
-	ansible-galaxy collection install -p ansible_collections kubernetes.core
-
-install: build install-kubernetes-src
+install: build
 	ansible-galaxy collection install -p ansible_collections community-okd-$(VERSION).tar.gz
+
+sanity: install
+	cd ansible_collections/community/okd && ansible-test sanity --docker -v --color --python $(PYTHON_VERSION) $(?TEST_ARGS)
+
+molecule:
+	molecule test
+
+test-integration: upstream-test-integration downstream-test-integration
+
+test-sanity: upstream-test-sanity downstream-test-sanity
 
 test-integration-incluster:
 	./ci/incluster_integration.sh
 
-test-sanity: upstream-test-sanity downstream-test-sanity
+upstream-test-sanity: sanity
 
-test-integration: upstream-test-integration downstream-test-integration
-
-upstream-test-integration: install
-	molecule test
-
-upstream-test-sanity: install
-	cd ansible_collections/community/okd && ansible-test sanity --exclude ci/ -v $(SANITY_TEST_ARGS)
+upstream-test-integration: molecule
 
 downstream-test-sanity:
 	./ci/downstream.sh -s

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Also needs to be updated in galaxy.yml
 VERSION = 1.1.2
 
-TEST_ARGS ?= ""
+TEST_ARGS ?= --docker --color
 PYTHON_VERSION ?= `python3 -c 'import platform; print("{0}.{1}".format(platform.python_version_tuple()[0], platform.python_version_tuple()[1]))'`
 
 clean:
@@ -18,7 +18,7 @@ install: build
 	ansible-galaxy collection install -p ansible_collections community-okd-$(VERSION).tar.gz
 
 sanity: install
-	cd ansible_collections/community/okd && ansible-test sanity --docker -v --color --python $(PYTHON_VERSION) $(?TEST_ARGS)
+	cd ansible_collections/community/okd && ansible-test sanity -v --python $(PYTHON_VERSION) $(TEST_ARGS)
 
 molecule:
 	molecule test

--- a/changelogs/fragments/89-clean-up-ci.yaml
+++ b/changelogs/fragments/89-clean-up-ci.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - fixes test suite to use correct versions of python and dependencies (https://github.com/ansible-collections/community.okd/pull/89).

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -221,7 +221,7 @@ f_test_integration_option()
     f_common_steps
     pushd "${_build_dir}" || return
         f_log_info "INTEGRATION TEST WD: ${PWD}"
-        OVERRIDE_COLLECTION_PATH="${_tmp_dir}" make molecule
+        make molecule
     popd || return
     f_cleanup
 }

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -202,6 +202,12 @@ f_test_sanity_option()
     f_log_info "${FUNCNAME[0]}"
     f_common_steps
     pushd "${_build_dir}" || return
+        if command -v docker &> /dev/null
+            then
+                make sanity
+            else
+                TEST_ARGS="--venv --color" make sanity
+            fi
         f_log_info "SANITY TEST PWD: ${PWD}"
         make sanity
     popd || return

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -67,6 +67,7 @@ f_prep()
         setup.cfg
         .yamllint
         requirements.txt
+        requirements.yml
     )
 
     # Directories to recursively copy downstream (relative repo root dir path)
@@ -179,17 +180,6 @@ f_handle_doc_fragments_workaround()
 
 }
 
-f_install_kubernetes_core()
-{
-    f_log_info "${FUNCNAME[0]}"
-    local install_collections_dir="${_tmp_dir}/ansible_collections"
-
-    pushd "${_tmp_dir}"
-        ansible-galaxy collection install -p "${install_collections_dir}" kubernetes.core
-    popd
-}
-
-
 f_copy_collection_to_working_dir()
 {
     f_log_info "${FUNCNAME[0]}"
@@ -211,20 +201,9 @@ f_test_sanity_option()
 {
     f_log_info "${FUNCNAME[0]}"
     f_common_steps
-    f_install_kubernetes_core
     pushd "${_build_dir}" || return
-        ansible-galaxy collection build
         f_log_info "SANITY TEST PWD: ${PWD}"
-        ## Can't do this because the upstream kubernetes.core dependency logic
-        ## is bound as a Makefile dep to the test-sanity target
-        #SANITY_TEST_ARGS="--docker --color --python 3.6" make test-sanity
-        # Run tests in docker if available, venv otherwise
-        if command -v docker &> /dev/null
-        then
-            ansible-test sanity --docker -v --exclude ci/ --color --python 3.6
-        else
-            ansible-test sanity --venv -v --exclude ci/ --color --python 3.6
-        fi
+        make sanity
     popd || return
     f_cleanup
 }
@@ -234,10 +213,9 @@ f_test_integration_option()
 {
     f_log_info "${FUNCNAME[0]}"
     f_common_steps
-    f_install_kubernetes_core
     pushd "${_build_dir}" || return
         f_log_info "INTEGRATION TEST WD: ${PWD}"
-        OVERRIDE_COLLECTION_PATH="${_tmp_dir}" molecule test
+        make molecule
     popd || return
     f_cleanup
 }
@@ -249,13 +227,7 @@ f_build_option()
     f_common_steps
     pushd "${_build_dir}" || return
         f_log_info "BUILD WD: ${PWD}"
-        # FIXME
-        #   This doesn't work because we end up either recursively curl'ing
-        #   kubernetes.core and redoing the text replacement over and over
-        #
-        # make build
-        ansible-galaxy collection build
-
+        make build
     popd || return
     f_copy_collection_to_working_dir
     f_cleanup

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -221,7 +221,7 @@ f_test_integration_option()
     f_common_steps
     pushd "${_build_dir}" || return
         f_log_info "INTEGRATION TEST WD: ${PWD}"
-        make molecule
+        OVERRIDE_COLLECTION_PATH="${_tmp_dir}" make molecule
     popd || return
     f_cleanup
 }

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -206,7 +206,7 @@ f_test_sanity_option()
             then
                 make sanity
             else
-                TEST_ARGS="--venv --color" make sanity
+                SANITY_TEST_ARGS="--venv --color" make sanity
             fi
         f_log_info "SANITY TEST PWD: ${PWD}"
         make sanity

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,6 +1,8 @@
 ---
 dependency:
   name: galaxy
+  options:
+    requirements-file: requirements.yml
 driver:
   name: delegated
 platforms:
@@ -38,6 +40,7 @@ verifier:
 scenario:
   name: default
   test_sequence:
+    - dependency
     - lint
     - syntax
     - prepare

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+collections:
+  - name: kubernetes.core
+    version: '>=1.2.0,<1.3.0'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There were a few problems with the existing build process, such as, the
python version not being passed during sanity tests and versions being
hard coded elsewhere. This change ensures that each test scenario gets
the correct parameters passed through. It also generally cleans up the
process for building the test environment to let ansible-galaxy do its
thing. This will make sure the correct version of dependencies get
installed.

Python 2.7 has been dropped from the test matrix for upstream sanity testing.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
N/A
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
