### PR TITLE
embeds the doc fragment of kubernetes.core

### DIFF
--- a/plugins/doc_fragments/k8s_auth_options.py
+++ b/plugins/doc_fragments/k8s_auth_options.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018,  Red Hat | Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Options for authenticating with the API.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+
+    DOCUMENTATION = r'''
+options:
+  host:
+    description:
+    - Provide a URL for accessing the API. Can also be specified via K8S_AUTH_HOST environment variable.
+    type: str
+  api_key:
+    description:
+    - Token used to authenticate with the API. Can also be specified via K8S_AUTH_API_KEY environment variable.
+    type: str
+  kubeconfig:
+    description:
+    - Path to an existing Kubernetes config file. If not provided, and no other connection
+      options are provided, the openshift client will attempt to load the default
+      configuration file from I(~/.kube/config.json). Can also be specified via K8S_AUTH_KUBECONFIG environment
+      variable.
+    type: path
+  context:
+    description:
+    - The name of a context found in the config file. Can also be specified via K8S_AUTH_CONTEXT environment variable.
+    type: str
+  username:
+    description:
+    - Provide a username for authenticating with the API. Can also be specified via K8S_AUTH_USERNAME environment
+      variable.
+    - Please note that this only works with clusters configured to use HTTP Basic Auth. If your cluster has a
+      different form of authentication (e.g. OAuth2 in OpenShift), this option will not work as expected and you
+      should look into the C(k8s_auth) module, as that might do what you need.
+    type: str
+  password:
+    description:
+    - Provide a password for authenticating with the API. Can also be specified via K8S_AUTH_PASSWORD environment
+      variable.
+    - Please read the description of the C(username) option for a discussion of when this option is applicable.
+    type: str
+  client_cert:
+    description:
+    - Path to a certificate used to authenticate with the API. Can also be specified via K8S_AUTH_CERT_FILE environment
+      variable.
+    type: path
+    aliases: [ cert_file ]
+  client_key:
+    description:
+    - Path to a key file used to authenticate with the API. Can also be specified via K8S_AUTH_KEY_FILE environment
+      variable.
+    type: path
+    aliases: [ key_file ]
+  ca_cert:
+    description:
+    - Path to a CA certificate used to authenticate with the API. The full certificate chain must be provided to
+      avoid certificate validation errors. Can also be specified via K8S_AUTH_SSL_CA_CERT environment variable.
+    type: path
+    aliases: [ ssl_ca_cert ]
+  validate_certs:
+    description:
+    - Whether or not to verify the API server's SSL certificates. Can also be specified via K8S_AUTH_VERIFY_SSL
+      environment variable.
+    type: bool
+    aliases: [ verify_ssl ]
+  proxy:
+    description:
+    - The URL of an HTTP proxy to use for the connection. Can also be specified via K8S_AUTH_PROXY environment variable.
+    - Please note that this module does not pick up typical proxy settings from the environment (e.g. HTTP_PROXY).
+    type: str
+  persist_config:
+    description:
+    - Whether or not to save the kube config refresh tokens.
+      Can also be specified via K8S_AUTH_PERSIST_CONFIG environment variable.
+    - When the k8s context is using a user credentials with refresh tokens (like oidc or gke/gcloud auth),
+      the token is refreshed by the k8s python client library but not saved by default. So the old refresh token can
+      expire and the next auth might fail. Setting this flag to true will tell the k8s python client to save the
+      new refresh token to the kube config file.
+    - Default to false.
+    - Please note that the current version of the k8s python client library does not support setting this flag to True yet.
+    - "The fix for this k8s python library is here: https://github.com/kubernetes-client/python-base/pull/169"
+    type: bool
+notes:
+  - "The OpenShift Python client wraps the K8s Python client, providing full access to
+    all of the APIS and models available on both platforms. For API version details and
+    additional information visit https://github.com/openshift/openshift-restclient-python"
+  - "To avoid SSL certificate validation errors when C(validate_certs) is I(True), the full
+    certificate chain for the API server must be provided via C(ca_cert) or in the
+    kubeconfig file."
+'''

--- a/plugins/doc_fragments/k8s_delete_options.py
+++ b/plugins/doc_fragments/k8s_delete_options.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Red Hat | Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Options for specifying object wait
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+
+    DOCUMENTATION = r'''
+options:
+  delete_options:
+    type: dict
+    version_added: '1.2.0'
+    description:
+    - Configure behavior when deleting an object.
+    - Only used when I(state=absent).
+    suboptions:
+      propagationPolicy:
+        type: str
+        description:
+        - Use to control how dependent objects are deleted.
+        - If not specified, the default policy for the object type will be used. This may vary across object types.
+        choices:
+        - "Foreground"
+        - "Background"
+        - "Orphan"
+      gracePeriodSeconds:
+        type: int
+        description:
+        - Specify how many seconds to wait before forcefully terminating.
+        - Only implemented for Pod resources.
+        - If not specified, the default grace period for the object type will be used.
+      preconditions:
+        type: dict
+        description:
+        - Specify condition that must be met for delete to proceed.
+        suboptions:
+          resourceVersion:
+            type: str
+            description:
+            - Specify the resource version of the target object.
+          uid:
+            type: str
+            description:
+            - Specify the UID of the target object.
+'''

--- a/plugins/doc_fragments/k8s_name_options.py
+++ b/plugins/doc_fragments/k8s_name_options.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Red Hat | Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Options for selecting or identifying a specific K8s object
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+
+    DOCUMENTATION = r'''
+options:
+  api_version:
+    description:
+    - Use to specify the API version.
+    - Use to create, delete, or discover an object without providing a full resource definition.
+    - Use in conjunction with I(kind), I(name), and I(namespace) to identify a specific object.
+    - If I(resource definition) is provided, the I(apiVersion) value from the I(resource_definition)
+      will override this option.
+    type: str
+    default: v1
+    aliases:
+    - api
+    - version
+  kind:
+    description:
+    - Use to specify an object model.
+    - Use to create, delete, or discover an object without providing a full resource definition.
+    - Use in conjunction with I(api_version), I(name), and I(namespace) to identify a specific object.
+    - If I(resource definition) is provided, the I(kind) value from the I(resource_definition)
+      will override this option.
+    type: str
+  name:
+    description:
+    - Use to specify an object name.
+    - Use to create, delete, or discover an object without providing a full resource definition.
+    - Use in conjunction with I(api_version), I(kind) and I(namespace) to identify a specific object.
+    - If I(resource definition) is provided, the I(metadata.name) value from the I(resource_definition)
+      will override this option.
+    type: str
+  namespace:
+    description:
+    - Use to specify an object namespace.
+    - Useful when creating, deleting, or discovering an object without providing a full resource definition.
+    - Use in conjunction with I(api_version), I(kind), and I(name) to identify a specific object.
+    - If I(resource definition) is provided, the I(metadata.namespace) value from the I(resource_definition)
+      will override this option.
+    type: str
+'''

--- a/plugins/doc_fragments/k8s_resource_options.py
+++ b/plugins/doc_fragments/k8s_resource_options.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Red Hat | Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Options for providing an object configuration
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+
+    DOCUMENTATION = r'''
+options:
+  resource_definition:
+    description:
+    - Provide a valid YAML definition (either as a string, list, or dict) for an object when creating or updating.
+    - "NOTE: I(kind), I(api_version), I(name), and I(namespace) will be overwritten by corresponding values found in the provided I(resource_definition)."
+    aliases:
+    - definition
+    - inline
+  src:
+    description:
+    - "Provide a path to a file containing a valid YAML definition of an object or objects to be created or updated. Mutually
+      exclusive with I(resource_definition). NOTE: I(kind), I(api_version), I(name), and I(namespace) will be
+      overwritten by corresponding values found in the configuration read in from the I(src) file."
+    - Reads from the local file system. To read from the Ansible controller's file system, including vaulted files, use the file lookup
+      plugin or template lookup plugin, combined with the from_yaml filter, and pass the result to
+      I(resource_definition). See Examples below.
+    - Mutually exclusive with I(template) in case of M(k8s) module.
+    type: path
+'''

--- a/plugins/doc_fragments/k8s_scale_options.py
+++ b/plugins/doc_fragments/k8s_scale_options.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018,  Red Hat | Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Options used by scale modules.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+
+    DOCUMENTATION = r'''
+options:
+  replicas:
+    description:
+      - The desired number of replicas.
+    type: int
+    required: True
+  current_replicas:
+    description:
+      - For Deployment, ReplicaSet, Replication Controller, only scale, if the number of existing replicas
+        matches. In the case of a Job, update parallelism only if the current parallelism value matches.
+    type: int
+  resource_version:
+    description:
+      - Only attempt to scale, if the current object version matches.
+    type: str
+  wait:
+    description:
+      - For Deployment, ReplicaSet, Replication Controller, wait for the status value of I(ready_replicas) to change
+        to the number of I(replicas). In the case of a Job, this option is ignored.
+    type: bool
+    default: yes
+  wait_timeout:
+    description:
+      - When C(wait) is I(True), the number of seconds to wait for the I(ready_replicas) status to equal  I(replicas).
+        If the status is not reached within the allotted time, an error will result. In the case of a Job, this option
+        is ignored.
+    type: int
+    default: 20
+'''

--- a/plugins/doc_fragments/k8s_state_options.py
+++ b/plugins/doc_fragments/k8s_state_options.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Red Hat | Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Options for specifying object state
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+
+    DOCUMENTATION = r'''
+options:
+  state:
+    description:
+    - Determines if an object should be created, patched, or deleted. When set to C(present), an object will be
+      created, if it does not already exist. If set to C(absent), an existing object will be deleted. If set to
+      C(present), an existing object will be patched, if its attributes differ from those specified using
+      I(resource_definition) or I(src).
+    type: str
+    default: present
+    choices: [ absent, present ]
+  force:
+    description:
+    - If set to C(yes), and I(state) is C(present), an existing object will be replaced.
+    type: bool
+    default: no
+'''

--- a/plugins/doc_fragments/k8s_wait_options.py
+++ b/plugins/doc_fragments/k8s_wait_options.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Red Hat | Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Options for specifying object wait
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+
+    DOCUMENTATION = r'''
+options:
+  wait:
+    description:
+    - Whether to wait for certain resource kinds to end up in the desired state.
+    - By default the module exits once Kubernetes has received the request.
+    - Implemented for C(state=present) for C(Deployment), C(DaemonSet) and C(Pod), and for C(state=absent) for all resource kinds.
+    - For resource kinds without an implementation, C(wait) returns immediately unless C(wait_condition) is set.
+    default: no
+    type: bool
+  wait_sleep:
+    description:
+    - Number of seconds to sleep between checks.
+    default: 5
+    type: int
+  wait_timeout:
+    description:
+    - How long in seconds to wait for the resource to end up in the desired state.
+    - Ignored if C(wait) is not set.
+    default: 120
+    type: int
+  wait_condition:
+    description:
+    - Specifies a custom condition on the status to wait for.
+    - Ignored if C(wait) is not set or is set to False.
+    suboptions:
+      type:
+        type: str
+        description:
+        - The type of condition to wait for.
+        - For example, the C(Pod) resource will set the C(Ready) condition (among others).
+        - Required if you are specifying a C(wait_condition).
+        - If left empty, the C(wait_condition) field will be ignored.
+        - The possible types for a condition are specific to each resource type in Kubernetes.
+        - See the API documentation of the status field for a given resource to see possible choices.
+      status:
+        type: str
+        description:
+        - The value of the status field in your desired condition.
+        - For example, if a C(Deployment) is paused, the C(Progressing) C(type) will have the C(Unknown) status.
+        choices:
+        - "True"
+        - "False"
+        - "Unknown"
+        default: "True"
+      reason:
+        type: str
+        description:
+        - The value of the reason field in your desired condition
+        - For example, if a C(Deployment) is paused, The C(Progressing) C(type) will have the C(DeploymentPaused) reason.
+        - The possible reasons in a condition are specific to each resource type in Kubernetes.
+        - See the API documentation of the status field for a given resource to see possible choices.
+    type: dict
+'''

--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -31,12 +31,12 @@ description:
   - Optimized for OKD/OpenShift Kubernetes flavors.
 
 extends_documentation_fragment:
-  - kubernetes.core.k8s_state_options
-  - kubernetes.core.k8s_name_options
-  - kubernetes.core.k8s_resource_options
-  - kubernetes.core.k8s_auth_options
-  - kubernetes.core.k8s_wait_options
-  - kubernetes.core.k8s_delete_options
+  - k8s_state_options
+  - k8s_name_options
+  - k8s_resource_options
+  - k8s_auth_options
+  - k8s_wait_options
+  - k8s_delete_options
 
 notes:
   - If your OpenShift Python library is not 0.9.0 or newer and you are trying to

--- a/plugins/modules/openshift_process.py
+++ b/plugins/modules/openshift_process.py
@@ -24,9 +24,9 @@ description:
   - For CRUD operations on Template resources themselves, see the community.okd.k8s module.
 
 extends_documentation_fragment:
-  - kubernetes.core.k8s_auth_options
-  - kubernetes.core.k8s_wait_options
-  - kubernetes.core.k8s_resource_options
+  - k8s_auth_options
+  - k8s_wait_options
+  - k8s_resource_options
 
 requirements:
   - "python >= 2.7"

--- a/plugins/modules/openshift_route.py
+++ b/plugins/modules/openshift_route.py
@@ -24,9 +24,9 @@ description:
   - For creating Services from other resources, see kubernetes.core.k8s_expose
 
 extends_documentation_fragment:
-  - kubernetes.core.k8s_auth_options
-  - kubernetes.core.k8s_wait_options
-  - kubernetes.core.k8s_state_options
+  - k8s_auth_options
+  - k8s_wait_options
+  - k8s_state_options
 
 requirements:
   - "python >= 2.7"


### PR DESCRIPTION
Import the documentation fragments of kubernetes.core stable-1.2.

See: https://github.com/ansible/ansible-zuul-jobs/issues/934
See: https://issues.redhat.com/browse/AAH-650