### PR TITLE
[stable-4]: Add .ansible-lint (#272)

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,6 @@
 ---
 profile: production
 exclude_paths:
-  - molecule
+  - tests/unit
   - tests/sanity
+  - molecule

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -64,6 +64,7 @@ f_prep()
     # Files to copy downstream (relative repo root dir path)
     _file_manifest=(
         .gitignore
+        .ansible-lint
         CHANGELOG.rst
         galaxy.yml
         LICENSE
@@ -77,7 +78,6 @@ f_prep()
 
     # Directories to recursively copy downstream (relative repo root dir path)
     _dir_manifest=(
-        .config
         changelogs
         ci
         meta


### PR DESCRIPTION
Backports https://github.com/openshift/community.okd/pull/272 to stable-4.