### PR TITLE
test(molecule): remove redundant virtualenv params

### DIFF
--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -65,6 +65,8 @@
     ansible_python_interpreter: '{{ virtualenv_interpreter }}'
 
   tasks:
+    # No explicit `virtualenv:` param is necessary with the following pip tasks.
+    # prepare.yml creates the venv and ansible_python_interpreter sets it.
     - pip:
         name: kubernetes-validate==1.34.1
 
@@ -73,9 +75,6 @@
     - pip:
         name: kubernetes-validate
         state: absent
-        virtualenv: "{{ virtualenv }}"
-        virtualenv_command: "{{ virtualenv_command }}"
-        virtualenv_site_packages: no
 
     - import_tasks: tasks/validate_not_installed.yml
 


### PR DESCRIPTION
This change removes left over virtualenv params from the kubernetes-validate cleanup pip task. Follows on from #274 

Needs backport to stable-5 and stable-4.