### PR TITLE
[stable-4]: fix(ci): pin ansible-core below 2.19 in ansible-lint tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
 [testenv:ansible-lint]
 deps =
   ansible-lint==6.21.0
-  ansible-core>=2.12.0,<2.19
+  ansible-core>=2.15.0,<2.19
 changedir = {toxinidir}
 commands =
   ansible-lint

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ commands =
 [testenv:ansible-lint]
 deps =
   ansible-lint==6.21.0
+  ansible-core>=2.12.0,<2.19
 changedir = {toxinidir}
 commands =
   ansible-lint


### PR DESCRIPTION
Fixes CI in https://github.com/openshift/community.okd/pull/281 and https://github.com/openshift/community.okd/pull/279

This change pins the ansible-core version becasue 2.19 removed `ansible.parsing.yaml.constructor` which ansible-lint imports directly, resulting in `ModuleNotFoundError`.

Verified the fix locally as well as by pushing this commit to #281 