### PR TITLE
[stable-5]: fix(ci): pin ansible-core below 2.19 in ansible-lint tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ commands =
 [testenv:ansible-lint]
 deps =
   ansible-lint >= 25.1.2
+  ansible-core>=2.16.0,<2.19
 changedir = {toxinidir}
 commands =
   ansible-lint


### PR DESCRIPTION
Related to https://github.com/openshift/community.okd/pull/282

This change adds an upper bound on ansible-core to prevent tox from resolving to the latest version.