### PR TITLE
Fix deprecated imports

### DIFF
--- a/changelogs/fragments/fix-deprecated-text-imports.yml
+++ b/changelogs/fragments/fix-deprecated-text-imports.yml
@@ -1,2 +1,2 @@
-bugfixes:
+minor_changes:
   - Replace deprecated ``ansible.module_utils._text`` imports with ``ansible.module_utils.common.text.converters`` to fix compatibility with ansible-core 2.24+ (https://github.com/openshift/community.okd/issues/275).

--- a/changelogs/fragments/fix-deprecated-text-imports.yml
+++ b/changelogs/fragments/fix-deprecated-text-imports.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Replace deprecated ``ansible.module_utils._text`` imports with ``ansible.module_utils.common.text.converters`` to fix compatibility with ansible-core 2.24+ (https://github.com/openshift/community.okd/issues/275).

--- a/plugins/module_utils/k8s.py
+++ b/plugins/module_utils/k8s.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     pass
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from kubernetes.dynamic.exceptions import (

--- a/plugins/module_utils/openshift_adm_prune_auth.py
+++ b/plugins/module_utils/openshift_adm_prune_auth.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.okd.plugins.module_utils.openshift_common import (
     AnsibleOpenshiftModule,

--- a/plugins/module_utils/openshift_adm_prune_deployments.py
+++ b/plugins/module_utils/openshift_adm_prune_deployments.py
@@ -6,7 +6,7 @@ __metaclass__ = type
 
 from datetime import datetime, timezone
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.okd.plugins.module_utils.openshift_common import (
     AnsibleOpenshiftModule,

--- a/plugins/module_utils/openshift_adm_prune_images.py
+++ b/plugins/module_utils/openshift_adm_prune_images.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 from datetime import datetime, timezone, timedelta
 import copy
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.six import iteritems
 

--- a/plugins/module_utils/openshift_builds.py
+++ b/plugins/module_utils/openshift_builds.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 from datetime import datetime, timezone, timedelta
 import time
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.okd.plugins.module_utils.openshift_common import (
     AnsibleOpenshiftModule,

--- a/plugins/module_utils/openshift_common.py
+++ b/plugins/module_utils/openshift_common.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 import traceback
 from abc import abstractmethod
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from ansible_collections.kubernetes.core.plugins.module_utils.k8s.client import (

--- a/plugins/module_utils/openshift_groups.py
+++ b/plugins/module_utils/openshift_groups.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 from datetime import datetime
 
 from ansible.module_utils.parsing.convert_bool import boolean
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import missing_required_lib
 
 from ansible_collections.community.okd.plugins.module_utils.openshift_ldap import (

--- a/plugins/module_utils/openshift_process.py
+++ b/plugins/module_utils/openshift_process.py
@@ -6,7 +6,7 @@ __metaclass__ = type
 
 import os
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.okd.plugins.module_utils.openshift_common import (
     AnsibleOpenshiftModule,

--- a/plugins/modules/openshift_adm_migrate_template_instances.py
+++ b/plugins/modules/openshift_adm_migrate_template_instances.py
@@ -233,7 +233,7 @@ result:
 """
 # ENDREMOVE (downstream)
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.okd.plugins.module_utils.openshift_common import (
     AnsibleOpenshiftModule,

--- a/plugins/modules/openshift_route.py
+++ b/plugins/modules/openshift_route.py
@@ -308,7 +308,7 @@ duration:
 
 import copy
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.okd.plugins.module_utils.openshift_common import (
     AnsibleOpenshiftModule,


### PR DESCRIPTION
  ---
  Title: Fix deprecated ansible.module_utils._text imports
     
  Body:

  ##### SUMMARY
  
  Replace deprecated `ansible.module_utils._text` imports with
  `ansible.module_utils.common.text.converters` across all 10 affected files.
  
  The `_text` module is deprecated as of ansible-core 2.20 and will be
  removed in 2.24. This change ensures forward compatibility while
  maintaining support for ansible-core 2.16+.
  
  Fixes #275
  
  ##### ISSUE TYPE

  - Bugfix Pull Request

  ##### COMPONENT NAME
  
  - plugins/module_utils/openshift_common.py
  - plugins/module_utils/k8s.py
  - plugins/module_utils/openshift_adm_prune_images.py
  - plugins/module_utils/openshift_process.py
  - plugins/modules/openshift_route.py
  - plugins/module_utils/openshift_builds.py
  - plugins/module_utils/openshift_groups.py
  - plugins/modules/openshift_adm_migrate_template_instances.py
  - plugins/module_utils/openshift_adm_prune_auth.py
  - plugins/module_utils/openshift_adm_prune_deployments.py
  
  ---
