### PR TITLE
[backport stable-5] replace ansible.module_utils.six imports with Python 3 stdlib, add ignores

### DIFF
--- a/changelogs/fragments/287-backport-replace-six-imports.yml
+++ b/changelogs/fragments/287-backport-replace-six-imports.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Replace ``ansible.module_utils.six`` imports (``iteritems``, ``string_types``) with Python 3 stdlib equivalents (https://github.com/openshift/community.okd/pull/287).
+  - Add sanity test ignore files for ansible-core 2.20 and 2.21 (https://github.com/openshift/community.okd/pull/287).

--- a/plugins/module_utils/openshift_adm_prune_images.py
+++ b/plugins/module_utils/openshift_adm_prune_images.py
@@ -9,7 +9,6 @@ import copy
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.parsing.convert_bool import boolean
-from ansible.module_utils.six import iteritems
 
 from ansible_collections.community.okd.plugins.module_utils.openshift_common import (
     AnsibleOpenshiftModule,
@@ -106,7 +105,7 @@ class OpenShiftAdmPruneImages(AnsibleOpenshiftModule):
 
     def list_objects(self):
         result = {}
-        for kind, version in iteritems(ApiConfiguration):
+        for kind, version in ApiConfiguration.items():
             namespace = None
             if self.params.get("namespace") and kind.lower() == "imagestream":
                 namespace = self.params.get("namespace")

--- a/plugins/module_utils/openshift_images_common.py
+++ b/plugins/module_utils/openshift_images_common.py
@@ -8,7 +8,6 @@ from datetime import datetime
 from ansible_collections.community.okd.plugins.module_utils.openshift_docker_image import (
     parse_docker_image_ref,
 )
-from ansible.module_utils.six import iteritems
 
 
 def get_image_blobs(image):
@@ -119,7 +118,7 @@ class OpenShiftAnalyzeImageStream(object):
             "CronJob",
         )
 
-        for k, objects in iteritems(resources):
+        for k, objects in resources.items():
             if k not in keys:
                 continue
             for obj in objects:
@@ -222,7 +221,7 @@ class OpenShiftAnalyzeImageStream(object):
     def analyze_refs_from_build_strategy(self, resources):
         # Json Path is always spec.strategy
         keys = ("BuildConfig", "Build")
-        for k, objects in iteritems(resources):
+        for k, objects in resources.items():
             if k not in keys:
                 continue
             for obj in objects:

--- a/plugins/module_utils/openshift_import_image.py
+++ b/plugins/module_utils/openshift_import_image.py
@@ -7,7 +7,6 @@ __metaclass__ = type
 import copy
 
 from ansible.module_utils.parsing.convert_bool import boolean
-from ansible.module_utils.six import string_types
 
 from ansible_collections.community.okd.plugins.module_utils.openshift_common import (
     AnsibleOpenshiftModule,
@@ -370,7 +369,7 @@ class OpenShiftImportImage(AnsibleOpenshiftModule):
     def execute_module(self):
         names = []
         name = self.params.get("name")
-        if isinstance(name, string_types):
+        if isinstance(name, str):
             names.append(name)
         elif isinstance(name, list):
             names = name

--- a/plugins/module_utils/openshift_ldap.py
+++ b/plugins/module_utils/openshift_ldap.py
@@ -12,7 +12,6 @@ import os
 import copy
 
 from ansible.module_utils.parsing.convert_bool import boolean
-from ansible.module_utils.six import iteritems
 
 try:
     import ldap
@@ -46,7 +45,7 @@ def validate_ldap_sync_config(config):
         return "could not read ca file: {0}.".format(ca_file)
 
     nameMapping = config.get("groupUIDNameMapping", {})
-    for k, v in iteritems(nameMapping):
+    for k, v in nameMapping.items():
         if len(k) == 0 or len(v) == 0:
             return "groupUIDNameMapping has empty key or value"
 

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,0 +1,3 @@
+plugins/modules/k8s.py validate-modules:parameter-type-not-in-doc
+plugins/modules/k8s.py validate-modules:return-syntax-error
+plugins/modules/openshift_process.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,0 +1,5 @@
+plugins/modules/k8s.py validate-modules:parameter-type-not-in-doc
+plugins/modules/k8s.py validate-modules:return-syntax-error
+plugins/modules/k8s.py validate-modules:bad-return-value-key
+plugins/modules/openshift_process.py validate-modules:parameter-type-not-in-doc
+plugins/modules/openshift_process.py validate-modules:bad-return-value-key


### PR DESCRIPTION
Backport of #286 to stable-5.

Since ansible-core 2.20 introduced a new pylint check (ansible-bad-import-from) that flags imports from ansible.module_utils.six, when a stdlib equivalent exists:
  
- Replaced iteritems() with dict.items() in 3 files
- Replace string_types with str in openshift_import_image.py
- Add tests/sanity/ignore-2.20.txt for validate-modules errors
- Add tests/sanity/ignore-2.21.txt for validate-modules errors
 
For issue #253
