### PR TITLE
Replace ansible.module_utils.six.moves.urllib_parse with stdlib urllibparse

### DIFF
--- a/changelogs/fragments/replace-six-urllib-parse.yml
+++ b/changelogs/fragments/replace-six-urllib-parse.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Replace ``ansible.module_utils.six.moves.urllib_parse`` import with Python 3 ``urllib.parse`` in ``openshift_auth`` module (https://github.com/openshift/community.okd/pull/291).

--- a/plugins/modules/openshift_auth.py
+++ b/plugins/modules/openshift_auth.py
@@ -174,8 +174,7 @@ k8s_auth:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib_parse import urlparse, parse_qs, urlencode
-from urllib.parse import urljoin
+from urllib.parse import urlparse, parse_qs, urlencode, urljoin
 
 from base64 import urlsafe_b64encode
 import hashlib


### PR DESCRIPTION
Small update to imports.

As requested by @oraNod in https://github.com/openshift/community.okd/pull/286