### PR TITLE
chore(dockerignore): ignore certain files from the container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.venv
+.git
+.idea
+.cache/
+__pycache__/
+*.tar.gz
+changelogs/.plugin-cache.yaml
+tests/output
+tests/integration/cloud-config-*


### PR DESCRIPTION
The Dockerfile copies everything in the repo root into the container image. This line: https://github.com/openshift/community.okd/blob/a16e726d3d1a219fef217857e94296cb045e7d9a/ci/Dockerfile#L30

I had a local venv that was getting built into the image which resulted in `bin/python` getting symlinked to `/usr/bin/python3.13`. In the container only Python3.12 is used so that symlink was broken and I got this error when running the `make test-integration-incluster` target:

```
ansible-galaxy collection build                                                              
  [ERROR]: Failed to find the target path '/usr/bin/python3.13' for the symlink                
  '/opt/ansible/.venv/bin/python'.                                                             
  make: *** [Makefile:16: build] Error 1                                                       
  + echo 'Molecule integration tests failed, see logs for more information...'                 
  Molecule integration tests failed, see logs for more information...                          
  + return 0                                                                                   
  + exit 1                                                                                     
  make: *** [Makefile:37: test-integration-incluster] Error 1 the specific error is [ERROR]:   
  Failed to find the target path '/usr/bin/python3.13' for the symlink
  ```
  
It seems sensible enough to add a `.dockerignore` file to match `.gitignore` and avoid unnecessary things getting built into the image.