### PR TITLE
test: bump kubernetes validate version

### DIFF
--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -66,7 +66,7 @@
 
   tasks:
     - pip:
-        name: kubernetes-validate==1.34.1
+        name: kubernetes-validate==1.35.0
 
     - import_tasks: tasks/validate_installed.yml
 


### PR DESCRIPTION
This change bumps the kubernetes-validate package to version 1.35 to add v1.35 schemas to validate tasks in molecule integration tests.

During a local test with crc the "incredibly simple ConfigMap" task failed with:

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "ConfigMap hello:
Kubernetes version v1.35.5 is not supported by kubernetes-validate"}
```