### PR TITLE
chore(OWNERS_ALIASES): add all senior software engineers and leadership to ownership file

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,11 +1,19 @@
 aliases:
   community.okd-approvers:
-    - gravesm
     - jillr
+    - GomathiselviS
     - alinabuzachis
     - abikouo
+    - beeankha
+    - mandar242
+    - oraNod
+    - brahmanim
   community.okd-reviewers:
-    - gravesm
     - jillr
+    - GomathiselviS
     - alinabuzachis
     - abikouo
+    - beeankha
+    - mandar242
+    - oraNod
+    - brahmanim


### PR DESCRIPTION
These users are the senior software engineers for the Ansible Nebula team, I am also going to try to request they be added to the openshift org as well so that they can interact with prow and add tags and such.