### PR TITLE
fix(downstream.sh): fix sed expression to match VERSION in makefile

### DIFF
--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -41,7 +41,7 @@ f_text_sub()
     sed -i.bak "s/Ansible Galaxy/Automation Hub/" "${_build_dir}/README.md"
     sed -i.bak "s/community-okd/redhat-openshift/" "${_build_dir}/Makefile"
     sed -i.bak "s/community\/okd/redhat\/openshift/" "${_build_dir}/Makefile"
-    sed -i.bak "s/^VERSION\:/VERSION: ${DOWNSTREAM_VERSION}/" "${_build_dir}/Makefile"
+    sed -i.bak "s/^VERSION = .*$/VERSION = ${DOWNSTREAM_VERSION}/" "${_build_dir}/Makefile"
     sed -i.bak "s/name\:.*$/name: openshift/" "${_build_dir}/galaxy.yml"
     sed -i.bak "s/namespace\:.*$/namespace: redhat/" "${_build_dir}/galaxy.yml"
     sed -i.bak "s/Kubernetes/OpenShift/g" "${_build_dir}/galaxy.yml"


### PR DESCRIPTION
While looking at integration test failures in https://github.com/openshift/community.okd/pull/296 I noticed the sed expression in the `ci/downstream.sh` script is not correct.

The `VERSION` field in the makefile has no colon: https://github.com/openshift/community.okd/blob/fd328e619f3a720bc338b517af00fb79d0922843/Makefile#L4

As a result the sed expression will never actually work as expected. Tested locally as follows:

```
$ cat Makefile 
VERSION = 6.0.0
$ sed -i "s/^VERSION\:/VERSION: 6.0.0-dev0/" Makefile 
$ cat Makefile 
VERSION = 6.0.0
```

With the corrected sed expression:

```
$ cat Makefile 
VERSION = 6.0.0
$ sed -i "s/^VERSION = .*$/VERSION = 6.0.0-dev0/" Makefile
$ cat Makefile 
VERSION = 6.0.0-dev0
```