### PR TITLE
chore: update for next major version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: molecule
 
 # Also needs to be updated in galaxy.yml
-VERSION = 6.0.0
+VERSION = 7.0.0-dev0
 
 SANITY_TEST_ARGS ?= --docker --color
 UNITS_TEST_ARGS ?= --docker --color

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -9,7 +9,7 @@
 #       - All functions are prefixed with f_ so it's obvious where they come
 #         from when in use throughout the script
 
-DOWNSTREAM_VERSION="6.0.0"
+DOWNSTREAM_VERSION="7.0.0-dev0"
 KEEP_DOWNSTREAM_TMPDIR="${KEEP_DOWNSTREAM_TMPDIR:-''}"
 INSTALL_DOWNSTREAM_COLLECTION_PATH="${INSTALL_DOWNSTREAM_COLLECTION_PATH:-}"
 _build_dir=""

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -24,4 +24,4 @@ tags:
   - okd
   - cluster
 # Also needs to be updated in the Makefile
-version: 6.0.0
+version: 7.0.0-dev0


### PR DESCRIPTION
Follows up on https://github.com/openshift/community.okd/pull/296 to update the `main` branch for the next major version.