### PR TITLE
Revert "Release community.okd 6.0.0 (#296)"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,30 +4,6 @@ OKD Collection Release Notes
 
 .. contents:: Topics
 
-v6.0.0
-======
-
-Release Summary
----------------
-
-This major release drops support for ansible-core versions below 2.16,
-replaces all ``ansible.module_utils.six`` imports with Python 3 stdlib equivalents,
-and fixes deprecated ``ansible.module_utils._text`` imports for compatibility
-with ansible-core 2.24+.
-
-Minor Changes
--------------
-
-- Add sanity test ignore files for ansible-core 2.20 and 2.21 (https://github.com/openshift/community.okd/pull/286).
-- Replace ``ansible.module_utils.six.moves.urllib_parse`` import with Python 3 ``urllib.parse`` in ``openshift_auth`` module (https://github.com/openshift/community.okd/pull/291).
-- Replace ``ansible.module_utils.six`` imports (``iteritems``, ``string_types``) with Python 3 stdlib equivalents (https://github.com/openshift/community.okd/pull/286).
-- Replace deprecated ``ansible.module_utils._text`` imports with ``ansible.module_utils.common.text.converters`` to fix compatibility with ansible-core 2.24+ (https://github.com/openshift/community.okd/issues/275).
-
-Breaking Changes / Porting Guide
---------------------------------
-
-- Minimum supported version of ansible-core is now 2.16 (https://github.com/openshift/community.okd/pull/292).
-
 v5.0.0
 ======
 
@@ -36,16 +12,16 @@ Release Summary
 
 This release drops support for ansible-lint < 25.1.2 and removes deprecated openshift inventory plugin.
 
+Breaking Changes / Porting Guide
+--------------------------------
+
+- Remove openshift inventory plugin deprecated in 3.0.0 (https://github.com/openshift/community.okd/pull/252).
+
 Minor Changes
 -------------
 
 - Bump version of ansible-lint to 25.1.2 (https://github.com/openshift/community.okd/pull/255).
 - Bump version of ansible-lint to minimum 24.7.0 (https://github.com/openshift/community.okd/pull/240).
-
-Breaking Changes / Porting Guide
---------------------------------
-
-- Remove openshift inventory plugin deprecated in 3.0.0 (https://github.com/openshift/community.okd/pull/252).
 
 v4.0.2
 ======

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -264,41 +264,10 @@ releases:
       minor_changes:
       - Bump version of ansible-lint to 25.1.2 (https://github.com/openshift/community.okd/pull/255).
       - Bump version of ansible-lint to minimum 24.7.0 (https://github.com/openshift/community.okd/pull/240).
-      release_summary: This release drops support for ansible-lint < 25.1.2 and removes
-        deprecated openshift inventory plugin.
+      release_summary: This release drops support for ansible-lint < 25.1.2 and removes deprecated openshift inventory plugin.
     fragments:
     - 240-bump-ansible-lint-version.yml
     - 5.0.0.yml
     - ansible-lint-update.yml
     - readme_template_update.yml
     release_date: '2025-06-10'
-  6.0.0:
-    changes:
-      breaking_changes:
-      - Minimum supported version of ansible-core is now 2.16 (https://github.com/openshift/community.okd/pull/292).
-      minor_changes:
-      - Add sanity test ignore files for ansible-core 2.20 and 2.21 (https://github.com/openshift/community.okd/pull/286).
-      - Replace ``ansible.module_utils.six.moves.urllib_parse`` import with Python
-        3 ``urllib.parse`` in ``openshift_auth`` module (https://github.com/openshift/community.okd/pull/291).
-      - Replace ``ansible.module_utils.six`` imports (``iteritems``, ``string_types``)
-        with Python 3 stdlib equivalents (https://github.com/openshift/community.okd/pull/286).
-      - Replace deprecated ``ansible.module_utils._text`` imports with ``ansible.module_utils.common.text.converters``
-        to fix compatibility with ansible-core 2.24+ (https://github.com/openshift/community.okd/issues/275).
-      release_summary: 'This major release drops support for ansible-core versions
-        below 2.16,
-
-        replaces all ``ansible.module_utils.six`` imports with Python 3 stdlib equivalents,
-
-        and fixes deprecated ``ansible.module_utils._text`` imports for compatibility
-
-        with ansible-core 2.24+.
-
-        '
-    fragments:
-    - 187-lowercase-booleans.yml
-    - 286-replace-six-imports.yml
-    - 292-bump-min-ansible-core.yml
-    - fix-deprecated-text-imports.yml
-    - replace-six-urllib-parse.yml
-    - v6.0.0-release-summary.yml
-    release_date: '2026-08-12'

--- a/changelogs/fragments/187-lowercase-booleans.yml
+++ b/changelogs/fragments/187-lowercase-booleans.yml
@@ -1,0 +1,2 @@
+trivial:
+  - Use lowercase true/false for boolean values in module documentation (https://github.com/openshift/community.okd/issues/187).

--- a/changelogs/fragments/286-replace-six-imports.yml
+++ b/changelogs/fragments/286-replace-six-imports.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Replace ``ansible.module_utils.six`` imports (``iteritems``, ``string_types``) with Python 3 stdlib equivalents (https://github.com/openshift/community.okd/pull/286).
+  - Add sanity test ignore files for ansible-core 2.20 and 2.21 (https://github.com/openshift/community.okd/pull/286).

--- a/changelogs/fragments/292-bump-min-ansible-core.yml
+++ b/changelogs/fragments/292-bump-min-ansible-core.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - Minimum supported version of ansible-core is now 2.16 (https://github.com/openshift/community.okd/pull/292).

--- a/changelogs/fragments/fix-deprecated-text-imports.yml
+++ b/changelogs/fragments/fix-deprecated-text-imports.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Replace deprecated ``ansible.module_utils._text`` imports with ``ansible.module_utils.common.text.converters`` to fix compatibility with ansible-core 2.24+ (https://github.com/openshift/community.okd/issues/275).

--- a/changelogs/fragments/replace-six-urllib-parse.yml
+++ b/changelogs/fragments/replace-six-urllib-parse.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Replace ``ansible.module_utils.six.moves.urllib_parse`` import with Python 3 ``urllib.parse`` in ``openshift_auth`` module (https://github.com/openshift/community.okd/pull/291).


### PR DESCRIPTION
This reverts commit 278886dfadb4980c27c38af5b0df9beb4f2e2f65.

The changes being reverted should have been made to the `stable-6` branch and not `main` as version 6.0.0 of the collection has not yet been released. Once that happens we can sync changes according to the release process docs at: https://github.com/ansible-collections/cloud-content-handbook/blob/main/Releases/release_collections.md