### PR TITLE
chore: update ansible-lint config

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,15 @@
 ---
+
 profile: production
+
 exclude_paths:
   - tests/unit
   - tests/sanity
   - molecule
+  - changelogs
+  - docs
+  - .ansible
+  - .github
+
+warn_list:
+  - no-log-password


### PR DESCRIPTION
This change updates the Ansible lint configuration to align with partner certification requirements at: https://docs.ansible.com/projects/partner-certification-requirements/static-analysis/#example-ansible-lint-configuration

Additionally this change resolves some linter issues with the version used by galaxy-importer: https://github.com/ansible-collections/partner-certification-checker/blob/6754a548046cbdc280620dae36df40f973bdf4c3/.github/workflows/certification-reusable.yml#L14

```
$ ansible-lint --version
ansible-lint 24.12.2 using ansible-core:2.16.0 ansible-compat:26.8.0 ruamel-yaml:0.19.1 ruamel-yaml-clib:None
```

Before this change:

```
# Rule Violation Summary

  2 key-order profile:basic tags:formatting
  7 jinja profile:basic tags:formatting
  6 no-free-form profile:basic tags:syntax,risk
 78 name profile:basic tags:idiom
  3 var-naming profile:basic tags:idiom
  4 yaml profile:basic tags:formatting,yaml
  1 yaml profile:basic tags:formatting,yaml
  1 yaml profile:basic tags:formatting,yaml
 55 yaml profile:basic tags:formatting,yaml
  2 yaml profile:basic tags:formatting,yaml
120 yaml profile:basic tags:formatting,yaml
  3 name profile:basic tags:idiom
 71 name profile:basic tags:idiom
  1 risky-file-permissions profile:basic tags:unpredictability
 14 ignore-errors profile:basic tags:unpredictability
 26 sanity profile:basic tags:idiom
215 fqcn profile:basic tags:formatting
 83 fqcn profile:basic tags:formatting
  2 args profile:basic tags:syntax,experimental

Failed: 685 failure(s), 9 warning(s) on 153 files. Last profile that met the validation criteria was 'min'.
```

After this change:

```
 ansible-lint ./

Passed: 0 failure(s), 0 warning(s) on 6 files. Profile 'production' was required, and it passed.
```